### PR TITLE
fix(test): isolate working-directory mutations across suites

### DIFF
--- a/scripts/test/coverage-ci.ts
+++ b/scripts/test/coverage-ci.ts
@@ -2,6 +2,7 @@ import { walk } from "#std/fs/walk";
 import {
   buildTestProcessEnv,
   LOOPBACK_TEST_PERMISSIONS,
+  partitionDenoSuiteFiles,
   UNIT_DENO_TEST_ENV,
 } from "./suites.ts";
 
@@ -150,10 +151,12 @@ async function runShard(args: string[]): Promise<void> {
   const { planSuiteFiles } = await import("./run-suite.ts");
   const { files } = await planSuiteFiles({ suite: "coverage:unit", shard });
 
-  await runDeno(
-    buildDenoTestCommandArgs({ coverageDir, files }),
-    { ...UNIT_COVERAGE_ENV },
-  );
+  for (const batch of partitionDenoSuiteFiles(files, null)) {
+    await runDeno(
+      buildDenoTestCommandArgs({ coverageDir, files: batch }),
+      { ...UNIT_COVERAGE_ENV },
+    );
+  }
 
   await clearEmptyCoverageProfileJson(coverageDir);
   const lcov = await captureDeno(buildCoverageCommandArgs([coverageDir]));

--- a/scripts/test/run-deno-suite.ts
+++ b/scripts/test/run-deno-suite.ts
@@ -5,6 +5,7 @@ import {
   DENO_TEST_ENV,
   hasDenoPermissionFlag,
   LOOPBACK_TEST_PERMISSIONS,
+  partitionDenoSuiteFiles,
   PROVIDER_EGRESS_DENY_NET,
   UNIT_DENO_TEST_ENV,
 } from "./suites.ts";
@@ -245,21 +246,6 @@ export function buildDenoSuiteCommandArgs(
     ...passthroughArgs,
     ...files,
   ];
-}
-
-export function partitionDenoSuiteFiles(
-  files: readonly string[],
-  maxFilesPerProcess: number | null,
-): string[][] {
-  if (maxFilesPerProcess === null || files.length <= maxFilesPerProcess) {
-    return [[...files]];
-  }
-
-  const batches: string[][] = [];
-  for (let start = 0; start < files.length; start += maxFilesPerProcess) {
-    batches.push(files.slice(start, start + maxFilesPerProcess));
-  }
-  return batches;
 }
 
 if (import.meta.main) {

--- a/scripts/test/run-suite.test.ts
+++ b/scripts/test/run-suite.test.ts
@@ -19,7 +19,11 @@ import {
   LOOPBACK_ALLOW_NET,
   parseDenoSuiteArgs,
 } from "./run-deno-suite.ts";
-import { LEAF_TEST_SUITES, partitionDenoSuiteFiles, PROVIDER_EGRESS_DENY_NET } from "./suites.ts";
+import {
+  LEAF_TEST_SUITES,
+  partitionDenoSuiteFiles,
+  PROVIDER_EGRESS_DENY_NET,
+} from "./suites.ts";
 import { classifyTestPath } from "./test-layout.ts";
 import {
   formatSuitePlan,
@@ -396,14 +400,21 @@ describe("migration command surface", () => {
       "tests/integration/cli/mcp/standalone-auth-scaffold.test.ts",
       "tests/integration/semantic-unit-boundary/cli/scaffold/missing-parent-race.test.ts",
     ];
-    const peers = ["cli/app/state.test.ts", "tests/docs/error-docs-links.test.ts"];
+    const peers = [
+      "cli/app/state.test.ts",
+      "tests/docs/error-docs-links.test.ts",
+    ];
     for (const limit of [2, 50, null]) {
       const batches = partitionDenoSuiteFiles([...peers, ...mutators], limit);
       assertEquals(batches.flat().sort(), [...peers, ...mutators].sort());
       for (const mutator of mutators) {
-        assertEquals(batches.find((batch) => batch.includes(mutator)), [mutator]);
+        assertEquals(batches.find((batch) => batch.includes(mutator)), [
+          mutator,
+        ]);
       }
-      assert(batches.some((batch) => peers.every((peer) => batch.includes(peer))));
+      assert(
+        batches.some((batch) => peers.every((peer) => batch.includes(peer))),
+      );
     }
   });
 

--- a/scripts/test/run-suite.test.ts
+++ b/scripts/test/run-suite.test.ts
@@ -18,9 +18,8 @@ import {
   DENO_SUITE_PROFILES,
   LOOPBACK_ALLOW_NET,
   parseDenoSuiteArgs,
-  partitionDenoSuiteFiles,
 } from "./run-deno-suite.ts";
-import { LEAF_TEST_SUITES, PROVIDER_EGRESS_DENY_NET } from "./suites.ts";
+import { LEAF_TEST_SUITES, partitionDenoSuiteFiles, PROVIDER_EGRESS_DENY_NET } from "./suites.ts";
 import { classifyTestPath } from "./test-layout.ts";
 import {
   formatSuitePlan,
@@ -30,6 +29,8 @@ import {
 } from "./run-suite.ts";
 
 const UNIT_CWD_FILES = [
+  "cli/auth/login.test.ts",
+  "cli/commands/build/embedded-preset-flags.test.ts",
   "cli/commands/skills/validate.test.ts",
   "src/platform/compat/process.test.ts",
   "src/testing/cwd.test.ts",
@@ -386,6 +387,24 @@ describe("migration command surface", () => {
     assert(cliIntegration.some((arg) => arg.startsWith("--deny-net=")));
     assert(cliIntegration.includes("--trace-leaks"));
     assertEquals(cliIntegration.at(-1), "cli/routes.integration.test.ts");
+  });
+
+  it("gives cwd-mutating fixtures their own process without serializing peers", () => {
+    const mutators = [
+      ...UNIT_CWD_FILES,
+      "tests/integration/adapters/shell-adapter.test.ts",
+      "tests/integration/cli/mcp/standalone-auth-scaffold.test.ts",
+      "tests/integration/semantic-unit-boundary/cli/scaffold/missing-parent-race.test.ts",
+    ];
+    const peers = ["cli/app/state.test.ts", "tests/docs/error-docs-links.test.ts"];
+    for (const limit of [2, 50, null]) {
+      const batches = partitionDenoSuiteFiles([...peers, ...mutators], limit);
+      assertEquals(batches.flat().sort(), [...peers, ...mutators].sort());
+      for (const mutator of mutators) {
+        assertEquals(batches.find((batch) => batch.includes(mutator)), [mutator]);
+      }
+      assert(batches.some((batch) => peers.every((peer) => batch.includes(peer))));
+    }
   });
 
   it("keeps the cross-file cwd exclusion probe concurrent", () => {

--- a/scripts/test/run-suite.ts
+++ b/scripts/test/run-suite.ts
@@ -7,7 +7,7 @@ import {
 } from "../../tests/test-file-utils.mjs";
 import { DENO_ONLY_TESTS } from "../../tests/deno-only-tests.mjs";
 import { discoverTests } from "./test-layout.ts";
-import { LEAF_TEST_SUITES } from "./suites.ts";
+import { LEAF_TEST_SUITES, UNIT_CWD_FILES } from "./suites.ts";
 
 export type SuitePlanId =
   | "unit:parallel"
@@ -70,11 +70,6 @@ const UNIT_ROOTS = (() => {
   }
   return unit.pathSelectors.filter((root) => !UNPLANNABLE_UNIT_ROOTS.has(root));
 })();
-const UNIT_CWD_FILES = [
-  "cli/commands/skills/validate.test.ts",
-  "src/platform/compat/process.test.ts",
-  "src/testing/cwd.test.ts",
-];
 // These tests own process-global lifecycle and require a quiet process.
 const UNIT_SERIAL_FILES = [
   "extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts",

--- a/scripts/test/suites.ts
+++ b/scripts/test/suites.ts
@@ -157,6 +157,46 @@ export function buildTestProcessEnv(
   return env;
 }
 
+/** Tests that intentionally change the process working directory. */
+export const UNIT_CWD_FILES: readonly string[] = Object.freeze([
+  "cli/auth/login.test.ts",
+  "cli/commands/build/embedded-preset-flags.test.ts",
+  "cli/commands/skills/validate.test.ts",
+  "src/platform/compat/process.test.ts",
+  "src/testing/cwd.test.ts",
+]);
+
+const CWD_MUTATING_TEST_FILES = new Set([
+  ...UNIT_CWD_FILES,
+  "tests/integration/adapters/shell-adapter.test.ts",
+  "tests/integration/cli/mcp/standalone-auth-scaffold.test.ts",
+  "tests/integration/semantic-unit-boundary/cli/scaffold/missing-parent-race.test.ts",
+]);
+
+/** Keep cwd writers in their own process, including in coverage shards. */
+export function partitionDenoSuiteFiles(
+  files: readonly string[],
+  maxFilesPerProcess: number | null,
+): string[][] {
+  const batches: string[][] = [];
+  let parallel: string[] = [];
+  for (const file of files) {
+    if (CWD_MUTATING_TEST_FILES.has(file)) {
+      if (parallel.length > 0) batches.push(parallel);
+      parallel = [];
+      batches.push([file]);
+    } else {
+      parallel.push(file);
+      if (parallel.length === maxFilesPerProcess) {
+        batches.push(parallel);
+        parallel = [];
+      }
+    }
+  }
+  if (parallel.length > 0 || batches.length === 0) batches.push(parallel);
+  return batches;
+}
+
 export type TestLevel = "unit" | "integration" | "e2e";
 
 export type TestRunner = "deno" | "node" | "bun" | "playwright";

--- a/tests/README.md
+++ b/tests/README.md
@@ -67,6 +67,14 @@ containers. A failed batch stops the remaining work, while process boundaries
 prevent completed modules and resources from accumulating for the entire run.
 Use `deno task test:file <path>` for the focused red-green loop.
 
+Tests that change the process working directory run in separate processes,
+including coverage shards. Register new cwd-mutating fixtures in
+`scripts/test/suites.ts`; the dedicated cross-file cwd-lock probes remain
+concurrent to test exclusion. A `withCwd` lock only coordinates callers that
+take it, so it cannot protect unrelated readers in another test file. Anchor
+repository reads to `import.meta.url` and pass an explicit `cwd` to child
+processes unless inherited cwd behavior is the subject of the test.
+
 ### Semantic Unit-Boundary Audit
 
 `deno task lint:test-semantic-dispositions` is the temporary semantic companion

--- a/tests/docs/error-docs-links.test.ts
+++ b/tests/docs/error-docs-links.test.ts
@@ -13,13 +13,14 @@ import { escapeMdxText } from "../../scripts/docs/generate-error-reference.ts";
 
 /** Prefix under which veryfront-code's docs/ tree is published. */
 const PUBLISHED_DOCS_PREFIX = "https://veryfront.com/docs/code/";
+const REPOSITORY_ROOT = new URL("../../", import.meta.url);
 
 /**
  * Resolve the published error-docs URL back to the repository file that has to
  * carry its anchors. Deriving the path (instead of hardcoding it) means moving
  * the page without moving ERROR_DOCS_BASE_URL fails this test.
  */
-function localFileForDocsBaseUrl(baseUrl: string): string {
+function localFileForDocsBaseUrl(baseUrl: string): URL {
   const withoutFragment = baseUrl.split("#")[0];
   assert(
     withoutFragment.startsWith(PUBLISHED_DOCS_PREFIX),
@@ -27,7 +28,7 @@ function localFileForDocsBaseUrl(baseUrl: string): string {
       `(${PUBLISHED_DOCS_PREFIX}...), got: ${baseUrl}`,
   );
   const docPath = withoutFragment.slice(PUBLISHED_DOCS_PREFIX.length);
-  return `docs/${docPath}.md`;
+  return new URL(`docs/${docPath}.md`, REPOSITORY_ROOT);
 }
 
 /**
@@ -45,7 +46,7 @@ function anchorsIn(markdown: string): Set<string> {
 }
 
 async function* walkTypeScript(dir: string): AsyncGenerator<string> {
-  for await (const entry of Deno.readDir(dir)) {
+  for await (const entry of Deno.readDir(new URL(dir, REPOSITORY_ROOT))) {
     const path = `${dir}/${entry.name}`;
     if (entry.isDirectory) yield* walkTypeScript(path);
     else if (entry.isFile && (path.endsWith(".ts") || path.endsWith(".tsx"))) yield path;
@@ -133,7 +134,7 @@ describe("error docs links", () => {
     for (const root of roots) {
       for await (const entry of walkTypeScript(root)) {
         if (entry.endsWith(".test.ts") || entry.includes(".generated.")) continue;
-        const source = await Deno.readTextFile(entry);
+        const source = await Deno.readTextFile(new URL(entry, REPOSITORY_ROOT));
         for (const line of source.split("\n")) {
           // The constant itself and doc comments describing the shape are fine.
           if (entry.endsWith("src/errors/diagnostic-policy.ts")) continue;

--- a/tests/integration/cli/mcp/tools/catalog-tools-project-creation.test.ts
+++ b/tests/integration/cli/mcp/tools/catalog-tools-project-creation.test.ts
@@ -114,6 +114,7 @@ describe("vfCreateProject filesystem conflicts", () => {
       new URL("../../../../../deno.json", import.meta.url),
     );
     const output = await new Deno.Command(Deno.execPath(), {
+      cwd: parentDir,
       args: [
         "run",
         "--allow-all",


### PR DESCRIPTION
Parallel Deno test files share the process working directory. The login and embedded-build fixtures were missing from the cwd lane, and three integration fixtures changed cwd while unrelated tests traversed repository files or launched child processes.

Run cwd-mutating fixtures in separate processes in both the normal suite runner and CI coverage shards, retaining parallel execution for other files. Anchor error-docs reads to the module URL and give the dependency-installer probe an explicit working directory. The existing cross-file cwd-lock probes remain concurrent.

Fixes veryfront/veryfront-issue-inbox#1043.

Validation:
- Reproduced the error-docs filesystem failures with the scaffold fixtures running in parallel; the same four-file command now passes all 24 steps.
- New suite-planning regressions failed before the fix; focused planner/coverage checks now pass all 38 steps, including complete and disjoint suite inventories.
- Full local pre-push checks passed: formatting, lint, typecheck, and 4,553 unit suites / 38,899 steps.
- Script typechecking, cwd-read audit, semantic audit, test layout, and diff checks passed.
- Local review of the implementation and the final formatting-only update found no actionable regressions. Tests requiring temporary-directory writes were independently verified outside the review sandbox.
- CI caught the scripts-specific formatting config; `deno task fmt:check` now passes, and the full pre-push gate passed again after the correction.
- Two full default-parallel root-integration runs passed, each with 605 suites / 3,980 steps. An intervening run hit a timer leak in the unchanged MDX shared-realm cache test; that test passed three isolated reruns and the next full integration run.
- Installed the pinned local Chromium binary after the first attempt exposed the missing browser; all three browser hydration checks then passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test execution reliability by isolating tests that change the working directory into separate processes.
  - Coverage runs now distribute test suites across batches while preserving working-directory isolation.
  - Documentation and integration checks now resolve repository files consistently, regardless of the launch directory.

- **Documentation**
  - Added guidance for handling working-directory-sensitive tests, including process isolation and reliable path resolution practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->