### PR TITLE
fix(ci): support complete large review timelines

### DIFF
--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -19,6 +19,8 @@ const REVIEW_REQUEST_MARKER =
 const FULL_SHA = /^[0-9a-f]{40}$/i;
 const REQUEST_KEY = /^[a-z0-9-]{1,64}$/i;
 const MAX_ITEMS_PER_SOURCE = 500;
+// Timelines include commits and lifecycle events as well as review evidence.
+const MAX_TIMELINE_ITEMS = 5000;
 const CODEX_REACTION_RETRY_DELAYS_MS = [1000, 2000, 4000];
 const MAX_TIMEOUT_TARGETS_PER_RUN = 25;
 const MAX_TIMEOUT_DISCOVERY_PAGES = 20;
@@ -1125,7 +1127,13 @@ export async function findAutomatedReview(
   )?.proof;
 }
 
-async function collectAll(github, endpoint, parameters, source) {
+async function collectAll(
+  github,
+  endpoint,
+  parameters,
+  source,
+  maxItems = MAX_ITEMS_PER_SOURCE,
+) {
   const items = [];
   for await (
     const response of github.paginate.iterator(endpoint, {
@@ -1137,8 +1145,8 @@ async function collectAll(github, endpoint, parameters, source) {
       throw new Error(`${source} pagination returned malformed data`);
     }
     items.push(...response.data);
-    if (items.length > MAX_ITEMS_PER_SOURCE) {
-      throw new Error(`${source} exceeded ${MAX_ITEMS_PER_SOURCE} items`);
+    if (items.length > maxItems) {
+      throw new Error(`${source} exceeded ${maxItems} items`);
     }
   }
   return items;
@@ -1189,6 +1197,7 @@ async function collectAutomatedReviewEvidence(
         github.rest.issues.listEventsForTimeline,
         { ...common, issue_number: pullNumber },
         source("pull request timeline"),
+        MAX_TIMELINE_ITEMS,
       ),
     ]);
   return { reviews, comments, reactions, events, statuses, timeline };
@@ -2281,6 +2290,7 @@ async function currentReviewPropagationRetry({
       github.rest.issues.listEventsForTimeline,
       { ...common, issue_number: pullNumber },
       "final review timeline",
+      MAX_TIMELINE_ITEMS,
     ),
   ]);
   const boundary = latestReviewEpochChange(events);

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1470,6 +1470,106 @@ function githubFixture(options: {
 }
 
 describe("automated review publication", () => {
+  it("reads complete review timelines beyond 500 items before accepting evidence", async () => {
+    const history = Array.from(
+      { length: 500 },
+      (_, index) => ({ event: "commented", id: 1000 + index }),
+    );
+    const verdict = codexComment(HEAD.slice(0, 10), { id: 101 });
+    const fixture = githubFixture({
+      pages: {
+        comments: [[verdict]],
+        timeline: [
+          history.slice(0, 100),
+          history.slice(100, 200),
+          history.slice(200, 300),
+          history.slice(300, 400),
+          history.slice(400),
+          [{ event: "commented", id: 101 }],
+        ],
+      },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(result.state, "success");
+    assertEquals(result.review?.source, "codex-comment");
+  });
+
+  it("keeps later same-second findings from being hidden beyond the first 500 timeline items", async () => {
+    const request = reviewRequestComment();
+    const verdict = codexComment(HEAD.slice(0, 10), {
+      id: 101,
+      created_at: request.created_at,
+    });
+    const finding = codexFindingComment(HEAD.slice(0, 10), {
+      id: 102,
+      created_at: request.created_at,
+    });
+    const history = Array.from(
+      { length: 498 },
+      (_, index) => ({ event: "commented", id: 1000 + index }),
+    );
+    const fixture = githubFixture({
+      pages: {
+        comments: [[request, verdict, finding]],
+        timeline: [[{ event: "commented", id: request.id }, {
+          event: "commented",
+          id: 101,
+        }, ...history], [{ event: "commented", id: 102 }]],
+      },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(result.state, "pending");
+    assertEquals(result.failure, undefined);
+    assertEquals(
+      fixture.published.some((status) => status.state === "success"),
+      false,
+    );
+  });
+
+  it("finalizes bounded review failures when their timeline exceeds 500 items", async () => {
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexRateLimitComment()]],
+        statuses: [[pendingAutomatedReviewStatus()]],
+        timeline: [
+          Array.from(
+            { length: 500 },
+            (_, index) => ({ event: "commented", id: 1000 + index }),
+          ),
+          [{ event: "committed", sha: HEAD }, { event: "commented", id: 103 }],
+        ],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      now: Date.parse("2026-08-25T08:05:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+    assertEquals(result.state, "failure");
+    assertEquals(result.description, "PR#1 automated review rate limited");
+  });
+
   it("retries a completed summary until its connector reaction is visible", async () => {
     let waits = 0;
     const fixture = githubFixture({
@@ -3449,7 +3549,7 @@ describe("automated review publication", () => {
     assertEquals(fixture.published[0]?.state, "pending");
   });
 
-  it("fails closed on partial pagination and the 500-item cap", async () => {
+  it("fails closed on partial pagination and source-specific item caps", async () => {
     const partialPages = [
       "reviews",
       "comments",
@@ -3468,6 +3568,14 @@ describe("automated review publication", () => {
         ...partialPages,
         githubFixture({
           pages: { reviews: [Array.from({ length: 501 }, () => review())] },
+        }),
+        githubFixture({
+          pages: {
+            timeline: Array.from({ length: 51 }, (_, page) =>
+              Array.from({ length: page === 50 ? 1 : 100 }, (_, index) => ({
+                event: "commented", id: 1000 + page * 100 + index,
+              }))),
+          },
         }),
       ]
     ) {


### PR DESCRIPTION
## Description

The automated review gate fails with `review status unavailable` after a PR accumulates more than 500 timeline events. This currently blocks #4454 even though the review/comment sources remain within their limits.

Allow up to 5,000 timeline events in both evidence collection and failure finalization. Keep the 500-item limit on other sources and reject incomplete, malformed, or over-limit pagination. Complete ordering evidence is retained, including findings beyond the first 500 events.

The workflow loads this script from the default branch, so this fix must land before #4454 can reconcile its review status.

## Related Issue(s)

Unblocks the review gate for #4454.

## Type of Change

- [x] Bug fix
- [x] Test update

## Validation

- `deno task test:file scripts/ci/automated-review-gate.test.ts`: 8 suites, 160 steps pass. Three new regressions failed before the fix.
- `deno check --config=scripts/test.deno.json scripts/ci/automated-review-gate.test.ts`: passes.
- `git diff --check`: passes.
- Coverage includes successful evidence after 500 events, a later same-second finding, rate-limit failure finalization, partial pagination, and both source limits.

## Checklist

- [x] No public documentation changes are needed.
- [x] Tests demonstrate the failure and the fix.
