### PR TITLE
fix(test): safely serialize lazy artifact import literals

### DIFF
--- a/tests/integration/transforms/mdx/shared-realm-cache.test.ts
+++ b/tests/integration/transforms/mdx/shared-realm-cache.test.ts
@@ -624,6 +624,7 @@ describe("MDX cache shared-realm lifecycle", () => {
     const dir = await makeTempDir();
     const source = "export const value = 63;";
     const artifact = dir + "/" + buildMdxJsxCacheFileName("/project/Species.tsx", source);
+    const artifactUrl = pathToFileURL(artifact).href;
     const species = Object.getOwnPropertyDescriptor(Array, Symbol.species);
     let release: (() => void) | undefined;
     try {
@@ -638,7 +639,7 @@ describe("MDX cache shared-realm lifecycle", () => {
         },
       });
       release = await retainJsxArtifactsReferencedIn(
-        `export const load = () => import(${JSON.stringify("file://" + artifact)});`,
+        `export const load = () => import("${artifactUrl}");`,
         dir,
       );
       await __jsxCacheInternals.runLazyJsxArtifactHeartbeat();

--- a/tests/integration/transforms/mdx/shared-realm-cache.test.ts
+++ b/tests/integration/transforms/mdx/shared-realm-cache.test.ts
@@ -40,6 +40,7 @@ import {
   MDX_JSX_CACHE_NAMESPACE_PREFIX,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
 import { utf8ByteLength } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/limits.ts";
+import { jsonForInlineScript } from "#veryfront/security/client/html-sanitizer.ts";
 
 type SourceSpanCounterOperation = "dynamic" | "side-effect" | "static";
 
@@ -621,10 +622,10 @@ describe("MDX cache shared-realm lifecycle", () => {
   });
 
   it("lazy retention and pruning do not consult Array species", async () => {
-    const dir = await makeTempDir();
+    const dir = await makeTempDir({ prefix: "vf species cache " });
     const source = "export const value = 63;";
     const artifact = dir + "/" + buildMdxJsxCacheFileName("/project/Species.tsx", source);
-    const artifactUrl = pathToFileURL(artifact).href;
+    const importLiteral = jsonForInlineScript("file://" + artifact);
     const species = Object.getOwnPropertyDescriptor(Array, Symbol.species);
     let release: (() => void) | undefined;
     try {
@@ -639,9 +640,11 @@ describe("MDX cache shared-realm lifecycle", () => {
         },
       });
       release = await retainJsxArtifactsReferencedIn(
-        `export const load = () => import("${artifactUrl}");`,
+        `export const load = () => import(${importLiteral});`,
         dir,
       );
+      assertEquals(__jsxCacheInternals.jsxArtifactActiveRefCount(artifact), 1);
+      assertEquals(__jsxCacheInternals.isLazyArtifactRetained(artifact), true);
       await __jsxCacheInternals.runLazyJsxArtifactHeartbeat();
       release();
       release = undefined;


### PR DESCRIPTION
## Summary

- Use the existing `jsonForInlineScript` serializer when constructing the synthetic lazy import in the Array species regression.
- Preserve the cache resolver's raw filesystem spelling while escaping script-breaking characters flagged by CodeQL alert 401.
- Exercise a temporary directory containing spaces and assert active/lazy retention directly, so the minimum-age grace period cannot hide a skipped retention path.
- No production behavior changes and no alert suppression.

## Verification

- Shared-realm cache integration suite: 26 cases pass on Deno and Node; the same file passes on Bun.
- Focused typecheck, lint, formatting and diff checks pass.
- The existing serializer has coverage for script-breaking characters and Unicode line separators.
- Local uncommitted and complete-branch Codex reviews pass with no actionable findings.

CodeQL must rescan the merged change before the default-branch alert can be considered resolved.
