### PR TITLE
fix(ci): stabilize config timing checks and patch Sharp

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -114,7 +114,7 @@
     "npm:remark-gfm@4.0.1": "4.0.1",
     "npm:remark-parse@11.0.0": "11.0.0",
     "npm:remark-rehype@11.1.2": "11.1.2",
-    "npm:sharp@0.35.3": "0.35.3",
+    "npm:sharp@0.35.4": "0.35.4",
     "npm:tailwind-scrollbar-hide@2.0.0": "2.0.0_tailwindcss@4.2.2",
     "npm:tailwindcss-animate@1.0.7": "1.0.7_tailwindcss@4.2.2",
     "npm:tailwindcss@4.2.2": "4.2.2",
@@ -1002,10 +1002,10 @@
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-darwin-arm64@0.35.3": {
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+    "@img/sharp-darwin-arm64@0.35.4": {
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "optionalDependencies": [
-        "@img/sharp-libvips-darwin-arm64@1.3.2"
+        "@img/sharp-libvips-darwin-arm64@1.3.3"
       ],
       "os": ["darwin"],
       "cpu": ["arm64"]
@@ -1018,18 +1018,18 @@
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@img/sharp-darwin-x64@0.35.3": {
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+    "@img/sharp-darwin-x64@0.35.4": {
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "optionalDependencies": [
-        "@img/sharp-libvips-darwin-x64@1.3.2"
+        "@img/sharp-libvips-darwin-x64@1.3.3"
       ],
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@img/sharp-freebsd-wasm32@0.35.3": {
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+    "@img/sharp-freebsd-wasm32@0.35.4": {
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "dependencies": [
-        "@img/sharp-wasm32@0.35.3"
+        "@img/sharp-wasm32@0.35.4"
       ],
       "os": ["freebsd"]
     },
@@ -1038,8 +1038,8 @@
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-libvips-darwin-arm64@1.3.2": {
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+    "@img/sharp-libvips-darwin-arm64@1.3.3": {
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
@@ -1048,8 +1048,8 @@
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@img/sharp-libvips-darwin-x64@1.3.2": {
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+    "@img/sharp-libvips-darwin-x64@1.3.3": {
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
@@ -1058,8 +1058,8 @@
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-libvips-linux-arm64@1.3.2": {
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+    "@img/sharp-libvips-linux-arm64@1.3.3": {
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
@@ -1068,8 +1068,8 @@
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "@img/sharp-libvips-linux-arm@1.3.2": {
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+    "@img/sharp-libvips-linux-arm@1.3.3": {
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
@@ -1078,8 +1078,8 @@
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
-    "@img/sharp-libvips-linux-ppc64@1.3.2": {
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+    "@img/sharp-libvips-linux-ppc64@1.3.3": {
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
@@ -1088,8 +1088,8 @@
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "@img/sharp-libvips-linux-riscv64@1.3.2": {
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+    "@img/sharp-libvips-linux-riscv64@1.3.3": {
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
@@ -1098,8 +1098,8 @@
       "os": ["linux"],
       "cpu": ["s390x"]
     },
-    "@img/sharp-libvips-linux-s390x@1.3.2": {
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+    "@img/sharp-libvips-linux-s390x@1.3.3": {
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "os": ["linux"],
       "cpu": ["s390x"]
     },
@@ -1108,8 +1108,8 @@
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@img/sharp-libvips-linux-x64@1.3.2": {
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+    "@img/sharp-libvips-linux-x64@1.3.3": {
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
@@ -1118,8 +1118,8 @@
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-libvips-linuxmusl-arm64@1.3.2": {
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+    "@img/sharp-libvips-linuxmusl-arm64@1.3.3": {
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
@@ -1128,8 +1128,8 @@
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@img/sharp-libvips-linuxmusl-x64@1.3.2": {
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+    "@img/sharp-libvips-linuxmusl-x64@1.3.3": {
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
@@ -1141,10 +1141,10 @@
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-linux-arm64@0.35.3": {
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+    "@img/sharp-linux-arm64@0.35.4": {
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-arm64@1.3.2"
+        "@img/sharp-libvips-linux-arm64@1.3.3"
       ],
       "os": ["linux"],
       "cpu": ["arm64"]
@@ -1157,10 +1157,10 @@
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "@img/sharp-linux-arm@0.35.3": {
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+    "@img/sharp-linux-arm@0.35.4": {
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-arm@1.3.2"
+        "@img/sharp-libvips-linux-arm@1.3.3"
       ],
       "os": ["linux"],
       "cpu": ["arm"]
@@ -1173,10 +1173,10 @@
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
-    "@img/sharp-linux-ppc64@0.35.3": {
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+    "@img/sharp-linux-ppc64@0.35.4": {
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-ppc64@1.3.2"
+        "@img/sharp-libvips-linux-ppc64@1.3.3"
       ],
       "os": ["linux"],
       "cpu": ["ppc64"]
@@ -1189,10 +1189,10 @@
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "@img/sharp-linux-riscv64@0.35.3": {
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+    "@img/sharp-linux-riscv64@0.35.4": {
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-riscv64@1.3.2"
+        "@img/sharp-libvips-linux-riscv64@1.3.3"
       ],
       "os": ["linux"],
       "cpu": ["riscv64"]
@@ -1205,10 +1205,10 @@
       "os": ["linux"],
       "cpu": ["s390x"]
     },
-    "@img/sharp-linux-s390x@0.35.3": {
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+    "@img/sharp-linux-s390x@0.35.4": {
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-s390x@1.3.2"
+        "@img/sharp-libvips-linux-s390x@1.3.3"
       ],
       "os": ["linux"],
       "cpu": ["s390x"]
@@ -1221,10 +1221,10 @@
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@img/sharp-linux-x64@0.35.3": {
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+    "@img/sharp-linux-x64@0.35.4": {
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-x64@1.3.2"
+        "@img/sharp-libvips-linux-x64@1.3.3"
       ],
       "os": ["linux"],
       "cpu": ["x64"]
@@ -1237,10 +1237,10 @@
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-linuxmusl-arm64@0.35.3": {
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+    "@img/sharp-linuxmusl-arm64@0.35.4": {
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linuxmusl-arm64@1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64@1.3.3"
       ],
       "os": ["linux"],
       "cpu": ["arm64"]
@@ -1253,10 +1253,10 @@
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@img/sharp-linuxmusl-x64@0.35.3": {
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+    "@img/sharp-linuxmusl-x64@0.35.4": {
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linuxmusl-x64@1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64@1.3.3"
       ],
       "os": ["linux"],
       "cpu": ["x64"]
@@ -1268,16 +1268,16 @@
       ],
       "cpu": ["wasm32"]
     },
-    "@img/sharp-wasm32@0.35.3": {
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+    "@img/sharp-wasm32@0.35.4": {
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "dependencies": [
         "@emnapi/runtime@1.11.3"
       ]
     },
-    "@img/sharp-webcontainers-wasm32@0.35.3": {
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+    "@img/sharp-webcontainers-wasm32@0.35.4": {
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "dependencies": [
-        "@img/sharp-wasm32@0.35.3"
+        "@img/sharp-wasm32@0.35.4"
       ],
       "cpu": ["wasm32"]
     },
@@ -1286,8 +1286,8 @@
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-win32-arm64@0.35.3": {
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+    "@img/sharp-win32-arm64@0.35.4": {
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
@@ -1296,8 +1296,8 @@
       "os": ["win32"],
       "cpu": ["ia32"]
     },
-    "@img/sharp-win32-ia32@0.35.3": {
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+    "@img/sharp-win32-ia32@0.35.4": {
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "os": ["win32"],
       "cpu": ["ia32"]
     },
@@ -1306,8 +1306,8 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@img/sharp-win32-x64@0.35.3": {
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+    "@img/sharp-win32-x64@0.35.4": {
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
@@ -5172,39 +5172,39 @@
       ],
       "scripts": true
     },
-    "sharp@0.35.3": {
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+    "sharp@0.35.4": {
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "dependencies": [
         "@img/colour",
         "detect-libc",
         "semver"
       ],
       "optionalDependencies": [
-        "@img/sharp-darwin-arm64@0.35.3",
-        "@img/sharp-darwin-x64@0.35.3",
+        "@img/sharp-darwin-arm64@0.35.4",
+        "@img/sharp-darwin-x64@0.35.4",
         "@img/sharp-freebsd-wasm32",
-        "@img/sharp-libvips-darwin-arm64@1.3.2",
-        "@img/sharp-libvips-darwin-x64@1.3.2",
-        "@img/sharp-libvips-linux-arm@1.3.2",
-        "@img/sharp-libvips-linux-arm64@1.3.2",
-        "@img/sharp-libvips-linux-ppc64@1.3.2",
-        "@img/sharp-libvips-linux-riscv64@1.3.2",
-        "@img/sharp-libvips-linux-s390x@1.3.2",
-        "@img/sharp-libvips-linux-x64@1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64@1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64@1.3.2",
-        "@img/sharp-linux-arm@0.35.3",
-        "@img/sharp-linux-arm64@0.35.3",
-        "@img/sharp-linux-ppc64@0.35.3",
-        "@img/sharp-linux-riscv64@0.35.3",
-        "@img/sharp-linux-s390x@0.35.3",
-        "@img/sharp-linux-x64@0.35.3",
-        "@img/sharp-linuxmusl-arm64@0.35.3",
-        "@img/sharp-linuxmusl-x64@0.35.3",
+        "@img/sharp-libvips-darwin-arm64@1.3.3",
+        "@img/sharp-libvips-darwin-x64@1.3.3",
+        "@img/sharp-libvips-linux-arm@1.3.3",
+        "@img/sharp-libvips-linux-arm64@1.3.3",
+        "@img/sharp-libvips-linux-ppc64@1.3.3",
+        "@img/sharp-libvips-linux-riscv64@1.3.3",
+        "@img/sharp-libvips-linux-s390x@1.3.3",
+        "@img/sharp-libvips-linux-x64@1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64@1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64@1.3.3",
+        "@img/sharp-linux-arm@0.35.4",
+        "@img/sharp-linux-arm64@0.35.4",
+        "@img/sharp-linux-ppc64@0.35.4",
+        "@img/sharp-linux-riscv64@0.35.4",
+        "@img/sharp-linux-s390x@0.35.4",
+        "@img/sharp-linux-x64@0.35.4",
+        "@img/sharp-linuxmusl-arm64@0.35.4",
+        "@img/sharp-linuxmusl-x64@0.35.4",
         "@img/sharp-webcontainers-wasm32",
-        "@img/sharp-win32-arm64@0.35.3",
-        "@img/sharp-win32-ia32@0.35.3",
-        "@img/sharp-win32-x64@0.35.3"
+        "@img/sharp-win32-arm64@0.35.4",
+        "@img/sharp-win32-ia32@0.35.4",
+        "@img/sharp-win32-x64@0.35.4"
       ]
     },
     "simple-concat@1.0.1": {
@@ -6561,7 +6561,7 @@
         "dependencies": [
           "jsr:@std/assert@1.0.19",
           "jsr:@std/testing@1.0.17",
-          "npm:sharp@0.35.3"
+          "npm:sharp@0.35.4"
         ]
       },
       "extensions/ext-llm-anthropic": {

--- a/extensions/ext-image-sharp/deno.json
+++ b/extensions/ext-image-sharp/deno.json
@@ -21,7 +21,7 @@
     ]
   },
   "imports": {
-    "sharp": "npm:sharp@0.35.3",
+    "sharp": "npm:sharp@0.35.4",
     "@std/assert": "jsr:@std/assert@1.0.19",
     "@std/testing/bdd": "jsr:@std/testing@1.0.17/bdd",
     "veryfront/extensions": "../../src/extensions/types.ts",

--- a/extensions/ext-image-sharp/src/index.test.ts
+++ b/extensions/ext-image-sharp/src/index.test.ts
@@ -54,7 +54,7 @@ describe("ext-image-sharp", () => {
 
   it("keeps cache identity immutable and backend-specific", () => {
     const engine = new SharpImageOptimizationEngine();
-    assertStringIncludes(engine.cacheIdentity, "sharp@0.35.4");
+    assertStringIncludes(engine.cacheIdentity, "|sharp@0.35.4|");
     assertStringIncludes(engine.cacheIdentity, `vips@${sharp.versions.vips}`);
     assertEquals(Object.isFrozen(engine), true);
     assertThrows(

--- a/extensions/ext-image-sharp/src/index.test.ts
+++ b/extensions/ext-image-sharp/src/index.test.ts
@@ -54,7 +54,7 @@ describe("ext-image-sharp", () => {
 
   it("keeps cache identity immutable and backend-specific", () => {
     const engine = new SharpImageOptimizationEngine();
-    assertStringIncludes(engine.cacheIdentity, "sharp@0.35.3");
+    assertStringIncludes(engine.cacheIdentity, "sharp@0.35.4");
     assertStringIncludes(engine.cacheIdentity, `vips@${sharp.versions.vips}`);
     assertEquals(Object.isFrozen(engine), true);
     assertThrows(

--- a/scripts/build/npm-extension-package-metadata.test.ts
+++ b/scripts/build/npm-extension-package-metadata.test.ts
@@ -67,7 +67,7 @@ describe("manifestDependencies", () => {
       veryfront?: { npm?: { nodeEngine?: string } };
     };
 
-    assertEquals(manifestDependencies(manifest), { sharp: "0.35.3" });
+    assertEquals(manifestDependencies(manifest), { sharp: "0.35.4" });
   });
 
   it("pins SQLite to a release that ships prebuilt binaries", async () => {

--- a/scripts/build/proxy-deno.lock
+++ b/scripts/build/proxy-deno.lock
@@ -1652,7 +1652,7 @@
         "dependencies": [
           "jsr:@std/assert@1.0.19",
           "jsr:@std/testing@1.0.17",
-          "npm:sharp@0.35.3"
+          "npm:sharp@0.35.4"
         ]
       },
       "extensions/ext-llm-anthropic": {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5889,13 +5889,11 @@ export default config as const;
         const control = await fastestLoad(
           "vf-config-dense-csi-control-",
           `throw new Error("aaaaa".repeat(${repeats}));\n`,
-          1,
         );
         const controlMs = Math.max(1, control.ms);
         const { ms: probeMs, error } = await fastestLoad(
           "vf-config-dense-csi-probe-",
           `throw new Error((String.fromCharCode(27) + "[31m").repeat(${repeats}));\n`,
-          1,
         );
 
         assertEquals(
@@ -5912,13 +5910,11 @@ export default config as const;
         const control = await fastestLoad(
           "vf-config-spaced-csi-control-",
           `throw new Error("a".repeat(${gap + 5}).repeat(${repeats}));\n`,
-          1,
         );
         const controlMs = Math.max(1, control.ms);
         const { ms: probeMs, error } = await fastestLoad(
           "vf-config-spaced-csi-probe-",
           `throw new Error(("a".repeat(${gap}) + String.fromCharCode(27) + "[31m").repeat(${repeats}));\n`,
-          1,
         );
 
         assertEquals(
@@ -5935,13 +5931,11 @@ export default config as const;
         const control = await fastestLoad(
           "vf-config-spaced-colon-csi-control-",
           `throw new Error("a".repeat(${gap + 4}).repeat(${repeats}));\n`,
-          1,
         );
         const controlMs = Math.max(1, control.ms);
         const { ms: probeMs, error } = await fastestLoad(
           "vf-config-spaced-colon-csi-probe-",
           `throw new Error(("a".repeat(${gap}) + String.fromCharCode(27) + "[:H").repeat(${repeats}));\n`,
-          1,
         );
 
         assertEquals(


### PR DESCRIPTION
## Description

Main fails coverage when a single config-loader timing sample catches runner contention, and the security audit rejects Sharp 0.35.3.

- Use the existing fastest-of-three measurement for the three CSI reconstruction cases. Preserve their inputs, timing ratios, and error assertions.
- Upgrade the image extension to Sharp 0.35.4 to address GHSA-rgj7-g3m4-5g8c. Refresh both lockfiles and version expectations.

## Validation

- Config-loader suite: 402 steps pass, both normally and with coverage.
- Sharp extension: 7 steps pass, including real image optimization.
- Extension package metadata: 9 tests / 37 steps pass.
- `deno task typecheck` passes.
- `deno task audit`: both workspace and Storybook audits report zero vulnerabilities.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated image processing support to the latest patch-level release, incorporating its available fixes and refinements.

- **Tests**
  - Improved configuration-load timing checks by using consistent multi-run measurements, making results more representative and reliable.
  - Updated validation coverage to reflect the current image processing release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->