### PR TITLE
feat(sandbox): allow bounded background command timeouts

### DIFF
--- a/src/sandbox/agent-service-tools.test.ts
+++ b/src/sandbox/agent-service-tools.test.ts
@@ -85,10 +85,11 @@ function createCommandPayload(overrides: Record<string, unknown> = {}) {
 async function executeStartBackgroundCommand(
   tools: SandboxShellToolSet,
   command: string,
+  timeoutSeconds?: number,
 ): Promise<unknown> {
   const execute = tools.start_background_command?.execute;
   assertExists(execute);
-  return await execute({ command });
+  return await execute({ command, ...(timeoutSeconds === undefined ? {} : { timeoutSeconds }) });
 }
 
 describe("sandbox/agent-service-tools", () => {
@@ -121,6 +122,35 @@ describe("sandbox/agent-service-tools", () => {
     assertExists(tools.cancel_background_command);
     assertEquals(tools.readFile, undefined);
     assertEquals(tools.writeFile, undefined);
+  });
+
+  it("passes an explicit background command timeout to the sandbox", async () => {
+    mockFetch([
+      createSandboxSessionResponse(),
+      createOkResponse(),
+      jsonResponse(createCommandPayload()),
+      createOkResponse(),
+    ]);
+
+    const { tools, closeSandbox } = await createAgentServiceSandboxTools({
+      authToken: "test-token",
+      apiUrl: "https://api.example.com",
+      projectId: "project-123",
+      createBashTool,
+    });
+
+    try {
+      await executeStartBackgroundCommand(tools, "npm test", 600);
+    } finally {
+      await closeSandbox();
+    }
+
+    assertEquals(jsonBody(fetchCalls, 2), {
+      command: "npm test",
+      cwd: "/workspace",
+      projectReference: "project-123",
+      timeout_seconds: 600,
+    });
   });
 
   it("normalizes sandbox writeFiles entries before dispatch", async () => {

--- a/src/sandbox/agent-service-tools.ts
+++ b/src/sandbox/agent-service-tools.ts
@@ -15,7 +15,7 @@ const SANDBOX_WORKING_DIRECTORY_PREFIX_PATTERN =
 
 /** Public API contract for agent service sandbox background command client. */
 export interface AgentServiceSandboxBackgroundCommandClient {
-  startBackgroundCommand(command: string): Promise<BackgroundCommand>;
+  startBackgroundCommand(command: string, options?: ExecOptions): Promise<BackgroundCommand>;
   getBackgroundCommand(commandId: string): Promise<BackgroundCommand>;
   getBackgroundCommandOutput(commandId: string): Promise<BackgroundCommandOutput>;
   cancelBackgroundCommand(commandId: string): Promise<BackgroundCommand>;
@@ -97,7 +97,8 @@ export function createAgentServiceSandboxClient(
   const sandbox = new LazySandbox({ ...input, getProjectId });
 
   const getExecOptions = () => createProjectScopedExecOptions(getProjectId());
-  const getBackgroundCommandExecOptions = () => ({
+  const getBackgroundCommandExecOptions = (options?: ExecOptions) => ({
+    ...options,
     ...getExecOptions(),
     cwd: SANDBOX_WORKING_DIRECTORY,
   });
@@ -109,10 +110,10 @@ export function createAgentServiceSandboxClient(
     },
     readFile: (path) => sandbox.readFile(path),
     writeFiles: (files) => sandbox.writeFiles(files.map((file) => normalizeSandboxWriteFile(file))),
-    startBackgroundCommand: (command) =>
+    startBackgroundCommand: (command, options) =>
       sandbox.startBackgroundCommand(
         unwrapSandboxWorkingDirectoryCommand(command),
-        getBackgroundCommandExecOptions(),
+        getBackgroundCommandExecOptions(options),
       ),
     getBackgroundCommand: (commandId) => sandbox.getBackgroundCommand(commandId),
     getBackgroundCommandOutput: (commandId) => sandbox.getBackgroundCommandOutput(commandId),
@@ -133,6 +134,9 @@ export function createAgentServiceSandboxClient(
 const getStartBackgroundCommandInputSchema = defineSchema((v) =>
   v.object({
     command: v.string().describe("Single shell command to run asynchronously in the sandbox"),
+    timeoutSeconds: v.number().int().positive().optional().describe(
+      "Optional command timeout in seconds. The sandbox applies its configured maximum.",
+    ),
   })
 );
 
@@ -155,7 +159,11 @@ export async function createAgentServiceSandboxTools(
       description:
         "Start a long-running sandbox command as an async background command. Use this instead of bash for durable shell operations.",
       inputSchema: getStartBackgroundCommandInputSchema(),
-      execute: async ({ command }) => await sandbox.startBackgroundCommand(command),
+      execute: async ({ command, timeoutSeconds }) =>
+        await sandbox.startBackgroundCommand(
+          command,
+          timeoutSeconds === undefined ? undefined : { timeout_seconds: timeoutSeconds },
+        ),
     }),
     get_background_command: tool({
       description:


### PR DESCRIPTION
## Problem

`start_background_command` is documented for long-running sandbox work, but its tool schema accepts only `command`. The sandbox therefore applies its 30-second default, so callers cannot run a bounded multi-minute command for rollout recovery verification.

## Change

- Add optional `timeoutSeconds` to the hosted background-command tool.
- Preserve the fixed `/workspace` and project scope while forwarding it as the existing sandbox `timeout_seconds` option.
- Keep omission behavior unchanged; the sandbox remains authoritative for its configured maximum.

This is the framework prerequisite for veryfront-agent draft PR #1857 and inbox issue veryfront/veryfront-issue-inbox#1024.

## Verification

- Red: the focused regression showed the sandbox command request omitted `timeout_seconds`.
- Green: pinned Deno 2.7.7 focused test passes all 7 steps.
- `deno check src/sandbox/agent-service-tools.ts` and focused formatting pass.
- Normal pre-push gate passed with pinned Deno: generation, formatting, lint, typecheck, and the complete unit suite.

No dependency, sandbox timeout-policy, API, or production configuration change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background commands can now accept an optional timeout.
  * Configured timeouts are forwarded to the execution service in seconds.

* **Bug Fixes**
  * Preserved caller-provided execution options when starting background commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->