### PR TITLE
feat(agent): emit native run event types instead of AG-UI Custom wrappers

### DIFF
--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -213,7 +213,8 @@ export async function GET() {
 Veryfront emits native AG-UI events for tool status, input requests, child-run
 status, citations, and attachments. Live SSE frames carry names such as
 `ChildRunStatusChanged`; durable records use `CHILD_RUN_STATUS_CHANGED`. Readers
-also accept the earlier `Custom` events.
+also accept the earlier `Custom` events. Tool-status frames can omit the tool name
+or set it to `null`; the chat decoder preserves the status in either case.
 
 The public `buildInvokeAgentChildRunLifecycleCustomEvent` and
 `buildInvokeAgentChildRunProgressEvents` helpers retain the `{ type: "CUSTOM",

--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -208,6 +208,25 @@ export async function GET() {
 }
 ```
 
+## Native run events
+
+Veryfront emits native AG-UI events for tool status, input requests, child-run
+status, citations, and attachments. Live SSE frames carry names such as
+`ChildRunStatusChanged`; durable records use `CHILD_RUN_STATUS_CHANGED`. Readers
+also accept the earlier `Custom` events.
+
+The public `buildInvokeAgentChildRunLifecycleCustomEvent` and
+`buildInvokeAgentChildRunProgressEvents` helpers retain the `{ type: "CUSTOM",
+name, value }` lifecycle shape. Their schemas and publisher callbacks keep that
+contract. Veryfront converts these lifecycle events to native records when it
+prepares them for durable publication.
+
+An oversized tool-status, input-request, or child-run record becomes a
+`conversation-run-event-omitted` marker. The marker records the original event
+type and tool call ID when available; it does not retain the oversized payload.
+You must keep lifecycle payloads within the run event size limit to preserve their
+full content in stored history.
+
 ## Streaming
 
 ### Server-side streaming

--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -214,7 +214,9 @@ Veryfront emits native AG-UI events for tool status, input requests, child-run
 status, citations, and attachments. Live SSE frames carry names such as
 `ChildRunStatusChanged`; durable records use `CHILD_RUN_STATUS_CHANGED`. Readers
 also accept the earlier `Custom` events. Tool-status frames can omit the tool name
-or set it to `null`; the chat decoder preserves the status in either case.
+or set it to `null`; the chat decoder preserves the status in either case. Native
+event payloads reserve `type`, `elapsedMs`, and `emittedAt` for transport metadata.
+Put application timing data in nested fields.
 
 The public `buildInvokeAgentChildRunLifecycleCustomEvent` and
 `buildInvokeAgentChildRunProgressEvents` helpers retain the `{ type: "CUSTOM",

--- a/src/agent/ag-ui/chat-ui-chunk-encoder.test.ts
+++ b/src/agent/ag-ui/chat-ui-chunk-encoder.test.ts
@@ -228,7 +228,7 @@ describe("agent/ag-ui-chat-ui-chunk-encoder", () => {
     );
   });
 
-  it("encodes source documents as renderable custom events", () => {
+  it("encodes source documents as native citation events", () => {
     const encoder = createAgUiChatUiChunkEncoder({ timing: { nowMs: null, epochMs: null } });
     const sourceDocument: ChatUiMessageChunk = {
       type: "source-document",
@@ -239,15 +239,17 @@ describe("agent/ag-ui-chat-ui-chunk-encoder", () => {
     };
 
     assertEquals(encoder.encode(sourceDocument), [{
-      event: "Custom",
+      event: "DocumentCited",
       payload: {
-        name: "source-document",
-        value: sourceDocument,
+        sourceId: "knowledge/knowledge-ingest-20260723131451088-source.md",
+        mediaType: "text/markdown",
+        title: "knowledge/knowledge-ingest-20260723131451088-source.md",
+        filename: "knowledge/knowledge-ingest-20260723131451088-source.md",
       },
     }]);
   });
 
-  it("encodes source URLs as renderable custom events", () => {
+  it("encodes source URLs as native URL citation events", () => {
     const encoder = createAgUiChatUiChunkEncoder({ timing: { nowMs: null, epochMs: null } });
     const sourceUrl: ChatUiMessageChunk = {
       type: "source-url",
@@ -257,15 +259,16 @@ describe("agent/ag-ui-chat-ui-chunk-encoder", () => {
     };
 
     assertEquals(encoder.encode(sourceUrl), [{
-      event: "Custom",
+      event: "UrlCited",
       payload: {
-        name: "source-url",
-        value: sourceUrl,
+        sourceId: "web-1",
+        url: "https://example.com/reference",
+        title: "Reference",
       },
     }]);
   });
 
-  it("encodes files as renderable custom events", () => {
+  it("encodes files as native file attachment events", () => {
     const encoder = createAgUiChatUiChunkEncoder({ timing: { nowMs: null, epochMs: null } });
     const file: ChatUiMessageChunk = {
       type: "file",
@@ -274,10 +277,10 @@ describe("agent/ag-ui-chat-ui-chunk-encoder", () => {
     };
 
     assertEquals(encoder.encode(file), [{
-      event: "Custom",
+      event: "FileAttached",
       payload: {
-        name: "file",
-        value: file,
+        url: "https://cdn.example.com/report.pdf",
+        mediaType: "application/pdf",
       },
     }]);
   });

--- a/src/agent/ag-ui/encoder.test.ts
+++ b/src/agent/ag-ui/encoder.test.ts
@@ -78,7 +78,11 @@ describe("agent/ag-ui-encoder", () => {
         },
         {
           event: "ToolCallStart",
-          payload: { toolCallId: "tool-1", toolCallName: "web_search" },
+          payload: {
+            toolCallId: "tool-1",
+            toolCallName: "web_search",
+            parentMessageId: "assistant-1",
+          },
         },
       ],
     );
@@ -279,13 +283,14 @@ describe("agent/ag-ui-encoder", () => {
     assertEquals(
       mapRuntimeStreamEventToAgUiEvents(state, {
         type: "data-tool-call-status",
-        data: { toolCallId: "tool-1", status: "pending_input" },
+        data: { toolCallId: "tool-1", toolCallName: "create_file", status: "pending_input" },
       }),
       [{
-        event: "Custom",
+        event: "ToolCallStatusChanged",
         payload: {
-          name: "tool-call-status",
-          value: { toolCallId: "tool-1", status: "pending_input" },
+          toolCallId: "tool-1",
+          status: "pending_input",
+          toolCallName: "create_file",
         },
       }],
     );
@@ -320,6 +325,116 @@ describe("agent/ag-ui-encoder", () => {
         event: "ToolCallResult",
         payload: { toolCallId: "tool-3", result: { error: "Tool output denied" }, isError: true },
       }],
+    );
+  });
+
+  it("emits native frames for citations, attachments, and lifecycle names", () => {
+    const state = createAgUiEncoderState({ nowMs: null, epochMs: null });
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiEvents(state, {
+        type: "source-url",
+        sourceId: "web-1",
+        url: "https://example.com/reference",
+        title: "Reference",
+      }),
+      [{
+        event: "UrlCited",
+        payload: {
+          sourceId: "web-1",
+          url: "https://example.com/reference",
+          title: "Reference",
+        },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiEvents(state, {
+        type: "source-document",
+        sourceId: "knowledge/report.md",
+        mediaType: "text/markdown",
+        title: "Report",
+        filename: "knowledge/report.md",
+      }),
+      [{
+        event: "DocumentCited",
+        payload: {
+          sourceId: "knowledge/report.md",
+          mediaType: "text/markdown",
+          title: "Report",
+          filename: "knowledge/report.md",
+        },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiEvents(state, {
+        type: "file",
+        url: "https://cdn.example.com/report.pdf",
+        mediaType: "application/pdf",
+        filename: "report.pdf",
+      }),
+      [{
+        event: "FileAttached",
+        payload: {
+          url: "https://cdn.example.com/report.pdf",
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiEvents(state, {
+        type: "data-veryfront.input_request.lifecycle",
+        data: {
+          action: "created",
+          inputRequest: { id: "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f", status: "open" },
+        },
+      }),
+      [{
+        event: "InputRequestCreated",
+        payload: {
+          inputRequest: { id: "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f", status: "open" },
+        },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiEvents(state, {
+        type: "data-veryfront.invoke_agent.lifecycle",
+        data: {
+          toolCallId: "toolu_child_1",
+          childRunId: "run_child_1",
+          status: "running",
+        },
+      }),
+      [{
+        event: "ChildRunStatusChanged",
+        payload: {
+          toolCallId: "toolu_child_1",
+          childRunId: "run_child_1",
+          status: "running",
+        },
+      }],
+    );
+  });
+
+  it("keeps state chunks and unknown data names custom", () => {
+    const state = createAgUiEncoderState({ nowMs: null, epochMs: null });
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiEvents(state, {
+        type: "data-state-delta",
+        data: [{ op: "replace", path: "/a", value: 1 }],
+      }),
+      [{
+        event: "Custom",
+        payload: {
+          name: "state-delta",
+          value: [{ op: "replace", path: "/a", value: 1 }],
+        },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiEvents(state, { type: "data-foo", data: { a: 1 } }),
+      [{ event: "Custom", payload: { name: "foo", value: { a: 1 } } }],
     );
   });
 
@@ -543,7 +658,11 @@ describe("agent/ag-ui-encoder", () => {
         },
         {
           event: "ToolCallStart",
-          payload: { toolCallId: "tool-4", toolCallName: "web_search" },
+          payload: {
+            toolCallId: "tool-4",
+            toolCallName: "web_search",
+            parentMessageId: "assistant-3",
+          },
         },
       ],
     );

--- a/src/agent/ag-ui/encoder.ts
+++ b/src/agent/ag-ui/encoder.ts
@@ -718,6 +718,20 @@ export function mapRuntimeStreamEventToAgUiEvents(
   );
 }
 
+/**
+ * The transport timing fields `stampAgUiEventTiming` writes onto a live
+ * event's own flat payload. Exported only so a reader that reconstructs a
+ * native frame's whole payload as legacy data -- e.g. the chat client's
+ * `stripAgUiTimingStamps` in `ag-ui.ts` -- can assert its strip list still
+ * covers every stamped field, instead of a third stamped field silently
+ * leaking into legacy `data` the way `elapsedMs`/`emittedAt` already did
+ * once on the durable-record read path (fixed in `legacy-run-read-adapter.ts`,
+ * commit 3ee902fb12) before this export existed to catch it in a test.
+ * `stampAgUiEventTiming` below keeps its own literals; this export adds no
+ * dependency to the runtime stamping path.
+ */
+export const AG_UI_EVENT_TIMING_STAMP_FIELDS = ["elapsedMs", "emittedAt"] as const;
+
 export function stampAgUiEventTiming(
   state: AgUiEncoderState,
   events: AgUiEncodedEvent[],

--- a/src/agent/ag-ui/encoder.ts
+++ b/src/agent/ag-ui/encoder.ts
@@ -1,4 +1,5 @@
 import type { AgentResponse } from "../types.ts";
+import { buildNativeRunEventFrame } from "./native-run-events.ts";
 
 /** Event emitted for AG-UI runtime stream. */
 export type AgUiRuntimeStreamEvent = Record<string, unknown> & { type: string };
@@ -786,15 +787,23 @@ function mapRuntimeStreamEventToAgUiEventsUnstamped(
     }
 
     state.sawVisibleOutput = true;
-    return [createCustomDataEvent(name, "data" in event ? event.data : null)];
+    const value = "data" in event ? event.data : null;
+    const native = buildNativeRunEventFrame({
+      name,
+      value,
+      parentMessageId: state.messageId,
+    });
+    return [native ? native.live : createCustomDataEvent(name, value)];
   }
 
   switch (event.type) {
     case "source-document":
     case "source-url":
-    case "file":
+    case "file": {
       state.sawVisibleOutput = true;
-      return [createCustomDataEvent(event.type, event)];
+      const native = buildNativeRunEventFrame({ name: event.type, value: event });
+      return [native ? native.live : createCustomDataEvent(event.type, event)];
+    }
 
     case "message-start":
       getMessageId(state, event);
@@ -892,6 +901,7 @@ function mapRuntimeStreamEventToAgUiEventsUnstamped(
         payload: {
           toolCallId: event.toolCallId,
           toolCallName: event.toolName,
+          ...(state.messageId ? { parentMessageId: state.messageId } : {}),
         },
       });
       return events;
@@ -1012,11 +1022,18 @@ function mapRuntimeStreamEventToAgUiEventsUnstamped(
         },
       ];
 
-    default:
+    default: {
       if (typeof event.type === "string" && event.type.startsWith("data-")) {
-        return [createCustomDataEvent(event.type.slice(5), event.data)];
+        const name = event.type.slice("data-".length);
+        const native = buildNativeRunEventFrame({
+          name,
+          value: event.data,
+          parentMessageId: state.messageId,
+        });
+        return [native ? native.live : createCustomDataEvent(name, event.data)];
       }
       return [];
+    }
   }
 }
 

--- a/src/agent/ag-ui/encoder.ts
+++ b/src/agent/ag-ui/encoder.ts
@@ -1036,18 +1036,11 @@ function mapRuntimeStreamEventToAgUiEventsUnstamped(
         },
       ];
 
-    default: {
-      if (typeof event.type === "string" && event.type.startsWith("data-")) {
-        const name = event.type.slice("data-".length);
-        const native = buildNativeRunEventFrame({
-          name,
-          value: event.data,
-          parentMessageId: state.messageId,
-        });
-        return [native ? native.live : createCustomDataEvent(name, event.data)];
-      }
+    default:
+      // The `data-` guard at the top of this function already returns for
+      // any event.type starting with "data-", so that case can never reach
+      // here -- this was a second, unreachable copy of the native routing.
       return [];
-    }
   }
 }
 

--- a/src/agent/ag-ui/lifecycle-adapter.test.ts
+++ b/src/agent/ag-ui/lifecycle-adapter.test.ts
@@ -489,4 +489,58 @@ describe("lifecycle AG-UI adapter", () => {
       },
     ]);
   });
+
+  it("emits native frames for tool status and custom lifecycle names", () => {
+    const adapter = createLifecycleAgUiAdapter({ messageId: "assistant-1" });
+
+    assertEquals(
+      adapter.encode({
+        class: "telemetry",
+        sequence: 1,
+        elapsedMs: 0,
+        event: {
+          type: "tool_input_status",
+          toolCallId: "tool-1",
+          toolCallName: "create_file",
+          status: "pending_input",
+        },
+      }),
+      [{
+        event: "ToolCallStatusChanged",
+        payload: {
+          toolCallId: "tool-1",
+          status: "pending_input",
+          toolCallName: "create_file",
+          parentMessageId: "assistant-1",
+        },
+      }],
+    );
+
+    assertEquals(
+      adapter.encode({
+        class: "semantic",
+        sequence: 2,
+        elapsedMs: 1,
+        event: {
+          type: "custom",
+          name: "source-url",
+          data: { type: "source-url", sourceId: "web-1", url: "https://example.com/a" },
+        },
+      }),
+      [{
+        event: "UrlCited",
+        payload: { sourceId: "web-1", url: "https://example.com/a" },
+      }],
+    );
+
+    assertEquals(
+      adapter.encode({
+        class: "semantic",
+        sequence: 3,
+        elapsedMs: 2,
+        event: { type: "custom", name: "state-delta", data: { ops: [] } },
+      }),
+      [{ event: "Custom", payload: { name: "state-delta", value: { ops: [] } } }],
+    );
+  });
 });

--- a/src/agent/ag-ui/lifecycle-adapter.ts
+++ b/src/agent/ag-ui/lifecycle-adapter.ts
@@ -4,6 +4,7 @@ import type {
   StreamUsage,
 } from "#veryfront/agent/streaming/lifecycle/index.ts";
 import type { AgUiEncodedEvent, AgUiRunFinishedMetadata } from "./encoder.ts";
+import { buildNativeRunEventFrame, buildToolCallStatusChangedEvent } from "./native-run-events.ts";
 
 /** Formatting-only state kept by the lifecycle AG-UI adapter. */
 export interface LifecycleAgUiState {
@@ -227,6 +228,7 @@ export function createLifecycleAgUiAdapter(input: {
           payload: {
             toolCallId: event.toolCallId,
             toolCallName: event.toolName,
+            parentMessageId: state.messageId,
           },
         }];
       case "tool_input_content":
@@ -311,12 +313,21 @@ export function createLifecycleAgUiAdapter(input: {
             stepName: state.activeStepName ?? `step-${state.stepCount || 1}`,
           },
         }];
-      case "custom":
+      case "custom": {
         state.sawVisibleOutput = true;
-        return [{
-          event: "Custom",
-          payload: { name: event.name, value: safeJson(event.data) },
-        }];
+        const value = safeJson(event.data);
+        const native = buildNativeRunEventFrame({
+          name: event.name,
+          value,
+          parentMessageId: state.messageId,
+        });
+        return [
+          native ? native.live : {
+            event: "Custom",
+            payload: { name: event.name, value },
+          },
+        ];
+      }
       case "usage":
         state.metadata = mergeUsageMetadata(state.metadata, event.usage);
         return [];
@@ -328,16 +339,14 @@ export function createLifecycleAgUiAdapter(input: {
       if (frame.class === "diagnostic") return [];
       if (frame.class === "telemetry") {
         return frame.event.type === "tool_input_status"
-          ? [{
-            event: "Custom",
-            payload: {
-              name: "tool-call-status",
-              value: {
-                toolCallId: frame.event.toolCallId,
-                status: frame.event.status,
-              },
-            },
-          }]
+          ? [
+            buildToolCallStatusChangedEvent({
+              toolCallId: frame.event.toolCallId,
+              status: frame.event.status,
+              toolCallName: frame.event.toolCallName,
+              parentMessageId: state.messageId,
+            }).live,
+          ]
           : [];
       }
       return encodeSemantic(frame.event);

--- a/src/agent/ag-ui/native-run-events.test.ts
+++ b/src/agent/ag-ui/native-run-events.test.ts
@@ -186,9 +186,7 @@ describe("agent/ag-ui-native-run-events", () => {
     );
     assertEquals(
       buildDocumentCitedEvent({ type: "source-document", mediaType: "text/markdown" }).live.payload,
-      // The projector also falls back to the source id for a missing title,
-      // the way it already does for a missing source id itself.
-      { mediaType: "text/markdown", sourceId: "text/markdown", title: "text/markdown" },
+      { mediaType: "text/markdown", sourceId: "text/markdown" },
     );
     assertEquals(
       buildFileAttachedEvent({
@@ -206,20 +204,16 @@ describe("agent/ag-ui-native-run-events", () => {
     );
   });
 
-  it("drops empty-string optionals from the durable record only, keeping the live wire frame lenient", () => {
+  it("drops empty-string optionals from the one payload both shapes share", () => {
     // The API declares title/filename/url as z.string().min(1).optional(), so
-    // an empty string is a hard rejection on the batch append route -- the
-    // durable record must drop it. The live wire frame must NOT: the chat
-    // decoder's UrlCited and FileAttached cases use a string url (for
-    // FileAttached) -- empty string included -- as their gate for rendering
-    // the citation/attachment at all (src/chat/ag-ui.ts), so dropping the
-    // key there would make it disappear rather than merely lose its title,
-    // exactly the legacy `Custom` wrapper never did. DocumentCited's title
-    // has the same gate but no drop-and-restore split, since it is never
-    // empty in either shape -- see the dedicated title-fallback test below.
-    // Required fields (url+sourceId, mediaType+sourceId, mediaType) are
-    // unaffected by this: they already go through readString with a
-    // non-empty fallback, in both shapes.
+    // an empty string is a hard rejection on the batch append route. The
+    // live wire frame gets the exact same drop, not a lenient copy: the API
+    // ingests that same SSE frame and stores it too (I1's own finding), so a
+    // value it would reject durably is exactly as unsafe there. Rendering a
+    // citation/attachment despite a dropped title/url is the chat decoder's
+    // job (src/chat/ag-ui.ts), not this builder's. Required fields
+    // (url+sourceId, mediaType+sourceId, mediaType) are unaffected by this:
+    // they already go through readString with a non-empty fallback.
     assertEquals(
       buildUrlCitedEvent({
         type: "source-url",
@@ -228,13 +222,10 @@ describe("agent/ag-ui-native-run-events", () => {
         title: "",
       }),
       {
-        live: {
-          event: "UrlCited",
-          payload: { sourceId: "web-1", url: "https://a", title: "" },
-        },
+        live: { event: "UrlCited", payload: { sourceId: "web-1", url: "https://a" } },
         durable: { sourceId: "web-1", url: "https://a", type: "URL_CITED" },
       },
-      "an empty title must reach the live frame unchanged but be dropped from the durable record",
+      "an empty title must be dropped from both shapes",
     );
     assertEquals(
       buildUrlCitedEvent({
@@ -252,22 +243,17 @@ describe("agent/ag-ui-native-run-events", () => {
         type: "source-document",
         sourceId: "d1",
         mediaType: "text/markdown",
-        title: "Report",
+        title: "",
         filename: "",
       }),
       {
         live: {
           event: "DocumentCited",
-          payload: { sourceId: "d1", mediaType: "text/markdown", title: "Report", filename: "" },
+          payload: { sourceId: "d1", mediaType: "text/markdown" },
         },
-        durable: {
-          sourceId: "d1",
-          mediaType: "text/markdown",
-          title: "Report",
-          type: "DOCUMENT_CITED",
-        },
+        durable: { sourceId: "d1", mediaType: "text/markdown", type: "DOCUMENT_CITED" },
       },
-      "an empty filename must reach the live frame unchanged but be dropped from the durable record",
+      "an empty title and filename must both be dropped from both shapes",
     );
     assertEquals(
       buildDocumentCitedEvent({
@@ -289,13 +275,10 @@ describe("agent/ag-ui-native-run-events", () => {
         filename: "",
       }),
       {
-        live: {
-          event: "FileAttached",
-          payload: { mediaType: "application/pdf", url: "", filename: "" },
-        },
+        live: { event: "FileAttached", payload: { mediaType: "application/pdf" } },
         durable: { mediaType: "application/pdf", type: "FILE_ATTACHED" },
       },
-      "an empty url and filename must reach the live frame unchanged but be dropped from the durable record",
+      "an empty url and filename must both be dropped from both shapes",
     );
     assertEquals(
       buildFileAttachedEvent({
@@ -313,45 +296,60 @@ describe("agent/ag-ui-native-run-events", () => {
     );
   });
 
-  it("falls back an empty or missing DOCUMENT_CITED title to the source id, in both shapes", () => {
-    // Unlike its own filename or buildUrlCitedEvent's title, DocumentCited's
-    // title is required at the chat UI type level
-    // (ChatSourceDocumentUiPart.title is not optional), so the chat decoder
-    // uses a string title as its gate for rendering the citation at all.
-    // Dropping an empty one from the durable record the way the other
-    // optionals are dropped would make a replayed citation unrenderable, so
-    // this builder never lets title be empty in either shape -- it falls
-    // back to the source id instead, the same value it already falls back
-    // to when the chunk has no source id of its own.
-    assertEquals(
-      buildDocumentCitedEvent({
+  it("drops a null or wrong-typed optional string, not just an empty one", () => {
+    // Regression guard: the API catalog's z.string().min(1).optional() for
+    // title/filename/url accepts exactly two shapes -- a non-empty string,
+    // or the key absent -- so a null or wrong-typed value fails its type
+    // check just as surely as an empty string fails its length check. A
+    // builder-level `readString(rest.title) ?? sourceId`-style normalization
+    // used to catch this incidentally; dropping only empty strings after
+    // that was removed did not, and let a payload the API rejects reach
+    // both shapes again.
+    function assertOptionalStringSchemaValid(
+      payload: Record<string, unknown>,
+      keys: readonly string[],
+    ) {
+      for (const key of keys) {
+        const value = payload[key];
+        assertEquals(
+          value === undefined || (typeof value === "string" && value.length > 0),
+          true,
+          `${key} must be absent or a non-empty string to satisfy z.string().min(1).optional(), got ${
+            JSON.stringify(value)
+          }`,
+        );
+      }
+    }
+
+    for (const badTitle of [null, 42, { unexpected: true }, ["a"]]) {
+      const frame = buildUrlCitedEvent({
+        type: "source-url",
+        sourceId: "web-1",
+        url: "https://a",
+        title: badTitle,
+      });
+      assertOptionalStringSchemaValid(frame.live.payload, ["title"]);
+      assertOptionalStringSchemaValid(frame.durable, ["title"]);
+
+      const documentFrame = buildDocumentCitedEvent({
         type: "source-document",
-        sourceId: "doc-1",
+        sourceId: "d1",
         mediaType: "text/markdown",
-        title: "",
-      }),
-      {
-        live: {
-          event: "DocumentCited",
-          payload: { sourceId: "doc-1", mediaType: "text/markdown", title: "doc-1" },
-        },
-        durable: {
-          sourceId: "doc-1",
-          mediaType: "text/markdown",
-          title: "doc-1",
-          type: "DOCUMENT_CITED",
-        },
-      },
-      "an empty title must fall back to the source id in both shapes",
-    );
-    assertEquals(
-      buildDocumentCitedEvent({
-        type: "source-document",
-        mediaType: "text/markdown",
-      }).durable.title,
-      "text/markdown",
-      "a missing title falls back to the derived source id (here, the media type) the same way",
-    );
+        title: badTitle,
+        filename: badTitle,
+      });
+      assertOptionalStringSchemaValid(documentFrame.live.payload, ["title", "filename"]);
+      assertOptionalStringSchemaValid(documentFrame.durable, ["title", "filename"]);
+
+      const fileFrame = buildFileAttachedEvent({
+        type: "file",
+        mediaType: "application/pdf",
+        url: badTitle,
+        filename: badTitle,
+      });
+      assertOptionalStringSchemaValid(fileFrame.live.payload, ["url", "filename"]);
+      assertOptionalStringSchemaValid(fileFrame.durable, ["url", "filename"]);
+    }
   });
 
   it("routes every legacy name through the dispatcher", () => {

--- a/src/agent/ag-ui/native-run-events.test.ts
+++ b/src/agent/ag-ui/native-run-events.test.ts
@@ -186,7 +186,9 @@ describe("agent/ag-ui-native-run-events", () => {
     );
     assertEquals(
       buildDocumentCitedEvent({ type: "source-document", mediaType: "text/markdown" }).live.payload,
-      { mediaType: "text/markdown", sourceId: "text/markdown" },
+      // The projector also falls back to the source id for a missing title,
+      // the way it already does for a missing source id itself.
+      { mediaType: "text/markdown", sourceId: "text/markdown", title: "text/markdown" },
     );
     assertEquals(
       buildFileAttachedEvent({
@@ -201,6 +203,154 @@ describe("agent/ag-ui-native-run-events", () => {
         filename: "report.pdf",
         type: "FILE_ATTACHED",
       },
+    );
+  });
+
+  it("drops empty-string optionals from the durable record only, keeping the live wire frame lenient", () => {
+    // The API declares title/filename/url as z.string().min(1).optional(), so
+    // an empty string is a hard rejection on the batch append route -- the
+    // durable record must drop it. The live wire frame must NOT: the chat
+    // decoder's UrlCited and FileAttached cases use a string url (for
+    // FileAttached) -- empty string included -- as their gate for rendering
+    // the citation/attachment at all (src/chat/ag-ui.ts), so dropping the
+    // key there would make it disappear rather than merely lose its title,
+    // exactly the legacy `Custom` wrapper never did. DocumentCited's title
+    // has the same gate but no drop-and-restore split, since it is never
+    // empty in either shape -- see the dedicated title-fallback test below.
+    // Required fields (url+sourceId, mediaType+sourceId, mediaType) are
+    // unaffected by this: they already go through readString with a
+    // non-empty fallback, in both shapes.
+    assertEquals(
+      buildUrlCitedEvent({
+        type: "source-url",
+        sourceId: "web-1",
+        url: "https://a",
+        title: "",
+      }),
+      {
+        live: {
+          event: "UrlCited",
+          payload: { sourceId: "web-1", url: "https://a", title: "" },
+        },
+        durable: { sourceId: "web-1", url: "https://a", type: "URL_CITED" },
+      },
+      "an empty title must reach the live frame unchanged but be dropped from the durable record",
+    );
+    assertEquals(
+      buildUrlCitedEvent({
+        type: "source-url",
+        sourceId: "web-1",
+        url: "https://a",
+        title: "Reference",
+      }).live.payload,
+      { sourceId: "web-1", url: "https://a", title: "Reference" },
+      "a non-empty title must still be carried through",
+    );
+
+    assertEquals(
+      buildDocumentCitedEvent({
+        type: "source-document",
+        sourceId: "d1",
+        mediaType: "text/markdown",
+        title: "Report",
+        filename: "",
+      }),
+      {
+        live: {
+          event: "DocumentCited",
+          payload: { sourceId: "d1", mediaType: "text/markdown", title: "Report", filename: "" },
+        },
+        durable: {
+          sourceId: "d1",
+          mediaType: "text/markdown",
+          title: "Report",
+          type: "DOCUMENT_CITED",
+        },
+      },
+      "an empty filename must reach the live frame unchanged but be dropped from the durable record",
+    );
+    assertEquals(
+      buildDocumentCitedEvent({
+        type: "source-document",
+        sourceId: "d1",
+        mediaType: "text/markdown",
+        title: "Report",
+        filename: "report.md",
+      }).live.payload,
+      { sourceId: "d1", mediaType: "text/markdown", title: "Report", filename: "report.md" },
+      "a non-empty title and filename must still be carried through",
+    );
+
+    assertEquals(
+      buildFileAttachedEvent({
+        type: "file",
+        mediaType: "application/pdf",
+        url: "",
+        filename: "",
+      }),
+      {
+        live: {
+          event: "FileAttached",
+          payload: { mediaType: "application/pdf", url: "", filename: "" },
+        },
+        durable: { mediaType: "application/pdf", type: "FILE_ATTACHED" },
+      },
+      "an empty url and filename must reach the live frame unchanged but be dropped from the durable record",
+    );
+    assertEquals(
+      buildFileAttachedEvent({
+        type: "file",
+        mediaType: "application/pdf",
+        url: "https://cdn.example.com/a.pdf",
+        filename: "a.pdf",
+      }).live.payload,
+      {
+        mediaType: "application/pdf",
+        url: "https://cdn.example.com/a.pdf",
+        filename: "a.pdf",
+      },
+      "a non-empty url and filename must still be carried through",
+    );
+  });
+
+  it("falls back an empty or missing DOCUMENT_CITED title to the source id, in both shapes", () => {
+    // Unlike its own filename or buildUrlCitedEvent's title, DocumentCited's
+    // title is required at the chat UI type level
+    // (ChatSourceDocumentUiPart.title is not optional), so the chat decoder
+    // uses a string title as its gate for rendering the citation at all.
+    // Dropping an empty one from the durable record the way the other
+    // optionals are dropped would make a replayed citation unrenderable, so
+    // this builder never lets title be empty in either shape -- it falls
+    // back to the source id instead, the same value it already falls back
+    // to when the chunk has no source id of its own.
+    assertEquals(
+      buildDocumentCitedEvent({
+        type: "source-document",
+        sourceId: "doc-1",
+        mediaType: "text/markdown",
+        title: "",
+      }),
+      {
+        live: {
+          event: "DocumentCited",
+          payload: { sourceId: "doc-1", mediaType: "text/markdown", title: "doc-1" },
+        },
+        durable: {
+          sourceId: "doc-1",
+          mediaType: "text/markdown",
+          title: "doc-1",
+          type: "DOCUMENT_CITED",
+        },
+      },
+      "an empty title must fall back to the source id in both shapes",
+    );
+    assertEquals(
+      buildDocumentCitedEvent({
+        type: "source-document",
+        mediaType: "text/markdown",
+      }).durable.title,
+      "text/markdown",
+      "a missing title falls back to the derived source id (here, the media type) the same way",
     );
   });
 

--- a/src/agent/ag-ui/native-run-events.test.ts
+++ b/src/agent/ag-ui/native-run-events.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildChildRunStatusChangedEvent,
@@ -15,6 +15,12 @@ import {
   nativeRunEventTypes,
 } from "./native-run-events.ts";
 
+import {
+  AG_UI_EVENT_TIMING_STAMP_FIELDS,
+  createAgUiEncoderState,
+  stampAgUiEventTiming,
+} from "./encoder.ts";
+import { ConversationRunEventEncoder } from "../conversation/run-events.ts";
 import { parseAgUiSseResponse } from "./sse-parser.ts";
 
 const INPUT_REQUEST = {
@@ -138,6 +144,46 @@ describe("agent/ag-ui-native-run-events", () => {
     assertEquals(frames[0].live.payload.result, { type: "nested-result", ok: true });
     assertEquals(frames[0].durable.result, frames[0].live.payload.result);
   });
+
+  for (
+    const name of [
+      "tool-call-status",
+      "veryfront.invoke_agent.lifecycle",
+      "source-url",
+      "source-document",
+      "file",
+    ]
+  ) {
+    for (const field of AG_UI_EVENT_TIMING_STAMP_FIELDS) {
+      for (const supplied of ["application metadata", 42]) {
+        it(`keeps ${typeof supplied} ${field} out of ${name} transport timing`, () => {
+          const value: Record<string, unknown> = {
+            ...CHILD_RUN,
+            url: "https://example.com/source",
+            mediaType: "text/plain",
+            sourceId: "source-1",
+            [field]: supplied,
+            detail: { [field]: supplied },
+          };
+          const frame = buildNativeRunEventFrame({ name, value });
+          assertExists(frame);
+          const clocks = { nowMs: () => 50, epochMs: () => 1_700_000_000_000 };
+          const [live] = stampAgUiEventTiming(createAgUiEncoderState(clocks), [frame.live]);
+          const [durable] = new ConversationRunEventEncoder(clocks).stamp([frame.durable]);
+          assertExists(live);
+          assertExists(durable);
+          for (const payload of [live.payload, durable]) {
+            assertEquals(payload.elapsedMs, 0);
+            assertEquals(payload.emittedAt, 1_700_000_000_000);
+            assertEquals(payload.detail, { [field]: supplied });
+          }
+          assertEquals(Object.hasOwn(frame.live.payload, field), false);
+          assertEquals(Object.hasOwn(frame.durable, field), false);
+          assertEquals(value[field], supplied);
+        });
+      }
+    }
+  }
 
   it("selects the input request type from the action and drops the action field", () => {
     assertEquals(

--- a/src/agent/ag-ui/native-run-events.test.ts
+++ b/src/agent/ag-ui/native-run-events.test.ts
@@ -15,6 +15,8 @@ import {
   nativeRunEventTypes,
 } from "./native-run-events.ts";
 
+import { parseAgUiSseResponse } from "./sse-parser.ts";
+
 const INPUT_REQUEST = {
   id: "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f",
   conversationId: "a7c53a3d-feb2-4404-86e2-5c562455e46c",
@@ -112,6 +114,29 @@ describe("agent/ag-ui-native-run-events", () => {
         parentMessageId: "assistant-1",
       },
     );
+  });
+
+  it("keeps native event types when open input records contain a legacy type", async () => {
+    const frames = [
+      buildToolCallStatusChangedEvent({
+        type: "tool-call-status",
+        toolCallId: "tool-1",
+        status: "running",
+        result: { type: "nested-result", ok: true },
+      }),
+      buildChildRunStatusChangedEvent({ ...CHILD_RUN, type: "CUSTOM" }),
+    ] as const;
+    for (const frame of frames) {
+      const response = new Response(
+        `event: ${frame.live.event}\ndata: ${JSON.stringify(frame.live.payload)}\n\n`,
+        { headers: { "Content-Type": "text/event-stream" } },
+      );
+      const parsed = await parseAgUiSseResponse(response);
+      assertEquals(parsed.eventTypes, [frame.durable.type]);
+      assertEquals(Object.hasOwn(frame.live.payload, "type"), false);
+    }
+    assertEquals(frames[0].live.payload.result, { type: "nested-result", ok: true });
+    assertEquals(frames[0].durable.result, frames[0].live.payload.result);
   });
 
   it("selects the input request type from the action and drops the action field", () => {

--- a/src/agent/ag-ui/native-run-events.test.ts
+++ b/src/agent/ag-ui/native-run-events.test.ts
@@ -1,0 +1,279 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildChildRunStatusChangedEvent,
+  buildDocumentCitedEvent,
+  buildFileAttachedEvent,
+  buildInputRequestLifecycleEvent,
+  buildNativeRunEventFrame,
+  buildToolCallStatusChangedEvent,
+  buildUrlCitedEvent,
+  isNativeRunEventName,
+  NATIVE_RUN_EVENTS,
+  nativeRunEventStoredTypesByWireName,
+  nativeRunEventTypes,
+} from "./native-run-events.ts";
+
+const INPUT_REQUEST = {
+  id: "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f",
+  conversationId: "a7c53a3d-feb2-4404-86e2-5c562455e46c",
+  runId: "run_native_events_1",
+  toolCallId: "toolu_form_1",
+  kind: "form",
+  status: "open",
+  title: "Choose a deployment target",
+};
+
+const CHILD_RUN = {
+  toolCallId: "toolu_child_1",
+  childConversationId: "22222222-2222-4222-a222-222222222222",
+  childRunId: "run_child_1",
+  childMessageId: "33333333-3333-4333-a333-333333333333",
+  childAgentId: "researcher",
+  description: "Inspect logs",
+  status: "running",
+  sourceTargetKind: "project",
+  runtimeTargetKind: "main_branch",
+  targetEnvironmentId: null,
+  targetBranchId: null,
+};
+
+describe("agent/ag-ui-native-run-events", () => {
+  it("keeps the wire, stored, and legacy tables derived from one list", () => {
+    assertEquals(NATIVE_RUN_EVENTS.map((entry) => entry.wireName), [
+      "ToolCallStatusChanged",
+      "InputRequestCreated",
+      "InputRequestUpdated",
+      "ChildRunStatusChanged",
+      "UrlCited",
+      "DocumentCited",
+      "FileAttached",
+    ]);
+    assertEquals(
+      Object.values(nativeRunEventTypes),
+      NATIVE_RUN_EVENTS.map((entry) => entry.storedType),
+      "the camelCase table the run event enums spread must stay in list order",
+    );
+    assertEquals(
+      [...nativeRunEventStoredTypesByWireName.entries()],
+      NATIVE_RUN_EVENTS.map((entry) => [entry.wireName, entry.storedType]),
+    );
+  });
+
+  it("accepts the six legacy custom names and rejects everything else", () => {
+    for (
+      const name of [
+        "tool-call-status",
+        "veryfront.input_request.lifecycle",
+        "veryfront.invoke_agent.lifecycle",
+        "source-url",
+        "source-document",
+        "file",
+      ]
+    ) {
+      assertEquals(isNativeRunEventName(name), true, name);
+    }
+    for (const name of ["state-delta", "state-snapshot", "run-parked", "foo", "__proto__"]) {
+      assertEquals(isNativeRunEventName(name), false, name);
+    }
+  });
+
+  it("builds both emission shapes for a tool call status change", () => {
+    // The API projector produces {...value, toolCallId, status, toolCallName}
+    // for the same legacy value, so a value with no name yields a null name
+    // rather than an absent field.
+    assertEquals(
+      buildToolCallStatusChangedEvent({ toolCallId: "tool-1", status: "pending_input" }),
+      {
+        live: {
+          event: "ToolCallStatusChanged",
+          payload: { toolCallId: "tool-1", status: "pending_input", toolCallName: null },
+        },
+        durable: {
+          toolCallId: "tool-1",
+          status: "pending_input",
+          toolCallName: null,
+          type: "TOOL_CALL_STATUS_CHANGED",
+        },
+      },
+    );
+    assertEquals(
+      buildToolCallStatusChangedEvent({
+        toolCallId: "tool-1",
+        status: "streaming_input",
+        toolCallName: "create_file",
+        parentMessageId: "assistant-1",
+      }).live.payload,
+      {
+        toolCallId: "tool-1",
+        status: "streaming_input",
+        toolCallName: "create_file",
+        parentMessageId: "assistant-1",
+      },
+    );
+  });
+
+  it("selects the input request type from the action and drops the action field", () => {
+    assertEquals(
+      buildInputRequestLifecycleEvent({ action: "created", inputRequest: INPUT_REQUEST }),
+      {
+        live: { event: "InputRequestCreated", payload: { inputRequest: INPUT_REQUEST } },
+        durable: { inputRequest: INPUT_REQUEST, type: "INPUT_REQUEST_CREATED" },
+      },
+    );
+    assertEquals(
+      buildInputRequestLifecycleEvent({ action: "updated", inputRequest: INPUT_REQUEST }),
+      {
+        live: { event: "InputRequestUpdated", payload: { inputRequest: INPUT_REQUEST } },
+        durable: { inputRequest: INPUT_REQUEST, type: "INPUT_REQUEST_UPDATED" },
+      },
+    );
+  });
+
+  it("carries the child run lifecycle value through unchanged", () => {
+    assertEquals(buildChildRunStatusChangedEvent(CHILD_RUN), {
+      live: { event: "ChildRunStatusChanged", payload: CHILD_RUN },
+      durable: { ...CHILD_RUN, type: "CHILD_RUN_STATUS_CHANGED" },
+    });
+  });
+
+  it("drops the chunk type and fills the projector's derived fields on citations", () => {
+    assertEquals(
+      buildUrlCitedEvent({
+        type: "source-url",
+        sourceId: "web-1",
+        url: "https://example.com/reference",
+        title: "Reference",
+      }),
+      {
+        live: {
+          event: "UrlCited",
+          payload: {
+            sourceId: "web-1",
+            url: "https://example.com/reference",
+            title: "Reference",
+          },
+        },
+        durable: {
+          sourceId: "web-1",
+          url: "https://example.com/reference",
+          title: "Reference",
+          type: "URL_CITED",
+        },
+      },
+    );
+    // The projector falls back to the url when a source id is missing.
+    assertEquals(
+      buildUrlCitedEvent({ type: "source-url", url: "https://example.com/a" }).live.payload,
+      { url: "https://example.com/a", sourceId: "https://example.com/a" },
+    );
+    assertEquals(
+      buildDocumentCitedEvent({
+        type: "source-document",
+        sourceId: "knowledge/report.md",
+        mediaType: "text/markdown",
+        title: "Report",
+        filename: "knowledge/report.md",
+      }).durable,
+      {
+        sourceId: "knowledge/report.md",
+        mediaType: "text/markdown",
+        title: "Report",
+        filename: "knowledge/report.md",
+        type: "DOCUMENT_CITED",
+      },
+    );
+    assertEquals(
+      buildDocumentCitedEvent({ type: "source-document", mediaType: "text/markdown" }).live.payload,
+      { mediaType: "text/markdown", sourceId: "text/markdown" },
+    );
+    assertEquals(
+      buildFileAttachedEvent({
+        type: "file",
+        url: "https://cdn.example.com/report.pdf",
+        mediaType: "application/pdf",
+        filename: "report.pdf",
+      }).durable,
+      {
+        url: "https://cdn.example.com/report.pdf",
+        mediaType: "application/pdf",
+        filename: "report.pdf",
+        type: "FILE_ATTACHED",
+      },
+    );
+  });
+
+  it("routes every legacy name through the dispatcher", () => {
+    assertEquals(
+      buildNativeRunEventFrame({
+        name: "tool-call-status",
+        value: { toolCallId: "tool-1", status: "pending_input" },
+        parentMessageId: "assistant-1",
+      })?.live,
+      {
+        event: "ToolCallStatusChanged",
+        payload: {
+          toolCallId: "tool-1",
+          status: "pending_input",
+          toolCallName: null,
+          parentMessageId: "assistant-1",
+        },
+      },
+    );
+    assertEquals(
+      buildNativeRunEventFrame({
+        name: "veryfront.input_request.lifecycle",
+        value: { action: "updated", inputRequest: INPUT_REQUEST },
+      })?.durable,
+      { inputRequest: INPUT_REQUEST, type: "INPUT_REQUEST_UPDATED" },
+    );
+    assertEquals(
+      buildNativeRunEventFrame({
+        name: "veryfront.invoke_agent.lifecycle",
+        value: CHILD_RUN,
+      })?.durable,
+      { ...CHILD_RUN, type: "CHILD_RUN_STATUS_CHANGED" },
+    );
+    assertEquals(
+      buildNativeRunEventFrame({
+        name: "file",
+        value: { type: "file", url: "https://cdn.example.com/a.pdf", mediaType: "application/pdf" },
+      })?.live.event,
+      "FileAttached",
+    );
+  });
+
+  it("returns null for a name or value that has no native frame", () => {
+    // A null return is how the caller keeps the Custom wrapper, which is what
+    // state deltas, state snapshots, and unknown names must still get.
+    assertEquals(buildNativeRunEventFrame({ name: "state-delta", value: { ops: [] } }), null);
+    assertEquals(buildNativeRunEventFrame({ name: "foo", value: { a: 1 } }), null);
+    assertEquals(buildNativeRunEventFrame({ name: "tool-call-status", value: null }), null);
+    assertEquals(
+      buildNativeRunEventFrame({ name: "tool-call-status", value: { toolCallId: "tool-1" } }),
+      null,
+      "a status-less telemetry value cannot become a typed payload",
+    );
+    assertEquals(
+      buildNativeRunEventFrame({
+        name: "veryfront.input_request.lifecycle",
+        value: { action: "deleted", inputRequest: INPUT_REQUEST },
+      }),
+      null,
+    );
+    assertEquals(
+      buildNativeRunEventFrame({ name: "source-url", value: { type: "source-url" } }),
+      null,
+      "a citation with no url has no URL_CITED payload",
+    );
+    assertEquals(
+      buildNativeRunEventFrame({
+        name: "file",
+        value: { type: "file-change", mediaType: "text/plain", id: "f1", status: "modified" },
+      }),
+      null,
+      "a file-change value is FILES_CHANGED on the legacy path, never FileAttached",
+    );
+  });
+});

--- a/src/agent/ag-ui/native-run-events.ts
+++ b/src/agent/ag-ui/native-run-events.ts
@@ -140,22 +140,20 @@ const FILE_ATTACHED = NATIVE_RUN_EVENTS[6];
 // `type` is written last so a payload that still carries a chunk type can
 // never win over the stored type. No builder passes one through.
 //
-// `durablePayload` defaults to `livePayload` and only the three citation/file
-// builders pass a distinct one: the API's batch append route rejects an
-// empty-string `title`/`filename`/`url` outright (I1), so those builders drop
-// it from the durable record, but the chat decoder in src/chat/ag-ui.ts uses
-// a string `title` (DocumentCited) or `url` (FileAttached) -- empty string
-// included -- as its gate for rendering the citation/attachment at all, so
-// the live wire frame must keep the field exactly as the legacy `Custom`
-// wrapper carried it.
+// One payload feeds both shapes: the live wire frame is not just this
+// repo's own chat client either, the API ingests the same SSE frame and
+// stores it, so a value the append route would reject is exactly as unsafe
+// there as it is in the durable record (I1). Builders that need to keep a
+// citation/attachment renderable despite a dropped optional field do that on
+// the read side (src/chat/ag-ui.ts's decoder), not by giving this frame two
+// different payloads.
 function toFrame(
   definition: NativeRunEventEntry,
-  livePayload: Record<string, unknown>,
-  durablePayload: Record<string, unknown> = livePayload,
+  payload: Record<string, unknown>,
 ): NativeRunEventFrame {
   return {
-    live: { event: definition.wireName, payload: livePayload },
-    durable: { ...durablePayload, type: definition.storedType },
+    live: { event: definition.wireName, payload },
+    durable: { ...payload, type: definition.storedType },
   };
 }
 
@@ -170,21 +168,26 @@ function readRecord(value: unknown): Record<string, unknown> | null {
 }
 
 /**
- * Drop the listed keys from `rest` when their value is an empty string, for
- * the durable payload only (see `toFrame`). The API catalog declares
- * `title`/`filename`/`url` as `z.string().min(1).optional()`, so an empty
- * string is a hard validation failure on the batch append route while an
- * absent key, `null`, or any other value is not -- only the empty-string
- * case needs dropping, never passed through like the required fields' own
- * `readString` guard.
+ * Drop the listed keys from `rest` unless their value is a non-empty string.
+ * The API catalog declares `title`/`filename`/`url` as
+ * `z.string().min(1).optional()`, which accepts exactly two shapes: a
+ * non-empty string, or the key absent entirely. An empty string fails the
+ * length check; `null`, a number, an object, or anything else fails the type
+ * check outright -- so every one of those needs dropping, not just the empty
+ * string, unlike the required fields' own `readString` guard, which only
+ * ever needs a fallback because it always has one to fall back to. Applied
+ * to the one payload `toFrame` puts in both shapes; a builder that needs the
+ * citation/attachment to still render when the dropped field made it
+ * disappear restores that on the read side (src/chat/ag-ui.ts's decoder),
+ * not by keeping an invalid value here.
  */
-function omitEmptyStrings(
+function omitInvalidOptionalStrings(
   rest: Record<string, unknown>,
   keys: readonly string[],
 ): Record<string, unknown> {
   const result: Record<string, unknown> = { ...rest };
   for (const key of keys) {
-    if (result[key] === "") {
+    if (typeof result[key] !== "string" || result[key] === "") {
       delete result[key];
     }
   }
@@ -258,16 +261,21 @@ export function buildChildRunStatusChangedEvent(
  * required field. `buildNativeRunEventFrame` guards that case and keeps the
  * `Custom` wrapper instead; a direct caller must do the same.
  *
- * `title` reaches the live wire frame exactly as the chunk carried it,
- * empty string included, since the chat decoder's UrlCited case renders the
- * citation regardless of title; the durable record drops an empty one
- * instead, since the API catalog rejects it there.
+ * A `title` the API catalog would reject -- an empty string, or any
+ * non-string value -- is dropped from the one payload both shapes share, and
+ * is not restored here. The chat decoder's UrlCited case falls back to the
+ * citation's own resolved source id when title is absent, so the citation
+ * still renders with something.
  */
 export function buildUrlCitedEvent(source: Record<string, unknown>): NativeRunEventFrame {
   const { type: _type, ...rest } = source;
   const url = readString(rest.url) ?? "";
-  const payload = { ...rest, url, sourceId: readString(rest.sourceId) ?? url };
-  return toFrame(URL_CITED, payload, omitEmptyStrings(payload, ["title"]));
+  const payload = {
+    ...omitInvalidOptionalStrings(rest, ["title"]),
+    url,
+    sourceId: readString(rest.sourceId) ?? url,
+  };
+  return toFrame(URL_CITED, payload);
 }
 
 /**
@@ -277,25 +285,24 @@ export function buildUrlCitedEvent(source: Record<string, unknown>): NativeRunEv
  * that the API catalog rejects. Route through `buildNativeRunEventFrame`, which
  * guards it, rather than calling this directly with unvalidated input.
  *
- * `title` is never dropped, in either shape, unlike this event's own
- * `filename` or `buildUrlCitedEvent`'s `title`: `ChatSourceDocumentUiPart.title`
- * is a required chat UI field (not optional like its siblings), so the chat
- * decoder uses a string title as its gate for rendering the citation at all.
- * An empty title falls back to the source id instead -- the same value this
- * builder already falls back to when the chunk has no source id of its own
- * -- so the citation always has a renderable, API-valid title in both the
- * live frame and the durable record, with nothing for a later replay to
- * restore. `filename` reaches the live wire frame exactly as the chunk
- * carried it, empty string included, and the durable record drops an empty
- * one, since the API catalog rejects it there and the chat decoder never
- * gates rendering on it.
+ * A `title` or `filename` the API catalog would reject -- an empty string,
+ * or any non-string value -- is dropped from the one payload both shapes
+ * share, and is not restored here. `ChatSourceDocumentUiPart.title` is a
+ * required chat UI field (unlike `filename`), so the chat decoder falls back
+ * to the citation's source id when title is absent, the same way
+ * `buildUrlCitedEvent`'s title falls back for its own decoder case; that
+ * keeps the citation renderable without this builder needing to fake a
+ * non-empty title into a payload the API also receives.
  */
 export function buildDocumentCitedEvent(source: Record<string, unknown>): NativeRunEventFrame {
   const { type: _type, ...rest } = source;
   const mediaType = readString(rest.mediaType) ?? "";
-  const sourceId = readString(rest.sourceId) ?? mediaType;
-  const payload = { ...rest, mediaType, sourceId, title: readString(rest.title) ?? sourceId };
-  return toFrame(DOCUMENT_CITED, payload, omitEmptyStrings(payload, ["filename"]));
+  const payload = {
+    ...omitInvalidOptionalStrings(rest, ["title", "filename"]),
+    mediaType,
+    sourceId: readString(rest.sourceId) ?? mediaType,
+  };
+  return toFrame(DOCUMENT_CITED, payload);
 }
 
 /**
@@ -304,25 +311,22 @@ export function buildDocumentCitedEvent(source: Record<string, unknown>): Native
  * The caller decides whether the chunk is a plain file: `buildNativeRunEventFrame`
  * rejects a `file-change` value, which the API projects to `FILES_CHANGED`.
  *
- * `url`/`filename` reach the live wire frame exactly as the chunk carried
- * them, empty string included: the chat decoder's FileAttached case uses a
- * string `url` -- empty string included -- as its gate for rendering the
- * attachment at all, so dropping an empty one from the live frame would make
- * the attachment disappear instead of merely losing its url. The durable
- * record drops an empty url or filename instead, since the API catalog
- * rejects either there.
- *
- * Unlike `buildDocumentCitedEvent`'s title, `url` has no safe non-empty
- * fallback here -- a placeholder url would be an actively misleading,
- * possibly broken link -- so a chunk whose url was empty is, once stored,
- * indistinguishable on replay from one that never had a url at all: both
- * read back unrenderable. Known, accepted gap; the live frame still renders
- * it correctly the first time.
+ * A `url` or `filename` the API catalog would reject -- an empty string, or
+ * any non-string value -- is dropped from the one payload both shapes share,
+ * and is not restored here. The chat decoder's FileAttached case treats a
+ * missing url the same way the legacy `Custom` wrapper's
+ * `toRenderableCustomChunk` always did: it falls back to a raw, unrenderable
+ * data chunk rather than fabricating one, since unlike a title there is no
+ * safe non-empty placeholder for a url -- a fake one would be an actively
+ * misleading, possibly broken link.
  */
 export function buildFileAttachedEvent(source: Record<string, unknown>): NativeRunEventFrame {
   const { type: _type, ...rest } = source;
-  const payload = { ...rest, mediaType: readString(rest.mediaType) ?? "" };
-  return toFrame(FILE_ATTACHED, payload, omitEmptyStrings(payload, ["filename", "url"]));
+  const payload = {
+    ...omitInvalidOptionalStrings(rest, ["filename", "url"]),
+    mediaType: readString(rest.mediaType) ?? "",
+  };
+  return toFrame(FILE_ATTACHED, payload);
 }
 
 /** Routing input for one custom event name and its value. */

--- a/src/agent/ag-ui/native-run-events.ts
+++ b/src/agent/ag-ui/native-run-events.ts
@@ -137,8 +137,8 @@ const URL_CITED = NATIVE_RUN_EVENTS[4];
 const DOCUMENT_CITED = NATIVE_RUN_EVENTS[5];
 const FILE_ATTACHED = NATIVE_RUN_EVENTS[6];
 
-// `type` is written last so a payload that still carries a chunk type can
-// never win over the stored type. No builder passes one through.
+// Strip the reserved `type` field before publication so both readers use
+// the native event type, including when an open input record carries a chunk type.
 //
 // One payload feeds both shapes: the live wire frame is not just this
 // repo's own chat client either, the API ingests the same SSE frame and
@@ -151,9 +151,10 @@ function toFrame(
   definition: NativeRunEventEntry,
   payload: Record<string, unknown>,
 ): NativeRunEventFrame {
+  const { type: _type, ...nativePayload } = payload;
   return {
-    live: { event: definition.wireName, payload },
-    durable: { ...payload, type: definition.storedType },
+    live: { event: definition.wireName, payload: nativePayload },
+    durable: { ...nativePayload, type: definition.storedType },
   };
 }
 

--- a/src/agent/ag-ui/native-run-events.ts
+++ b/src/agent/ag-ui/native-run-events.ts
@@ -1,0 +1,296 @@
+/**
+ * Native run event vocabulary shared by every emission path.
+ *
+ * Veryfront Code used to wrap these seven occurrences in an AG-UI `Custom`
+ * frame and let the API translate the custom name back into a type. The API
+ * now accepts the native names, so this module owns the list once: the wire
+ * name a live SSE frame carries, the stored type a durable record carries, and
+ * the legacy custom name each one replaces. Both encoders build their frames
+ * here, so the live and durable shapes cannot drift apart.
+ */
+
+/** One native run event: its wire name, stored type, and the custom name it replaces. */
+export interface NativeRunEventDefinition {
+  wireName: string;
+  storedType: string;
+  legacyCustomName: string;
+}
+
+/** The native run events this runtime emits, in catalog order. */
+export const NATIVE_RUN_EVENTS = [
+  {
+    wireName: "ToolCallStatusChanged",
+    storedType: "TOOL_CALL_STATUS_CHANGED",
+    legacyCustomName: "tool-call-status",
+  },
+  {
+    wireName: "InputRequestCreated",
+    storedType: "INPUT_REQUEST_CREATED",
+    legacyCustomName: "veryfront.input_request.lifecycle",
+  },
+  {
+    wireName: "InputRequestUpdated",
+    storedType: "INPUT_REQUEST_UPDATED",
+    legacyCustomName: "veryfront.input_request.lifecycle",
+  },
+  {
+    wireName: "ChildRunStatusChanged",
+    storedType: "CHILD_RUN_STATUS_CHANGED",
+    legacyCustomName: "veryfront.invoke_agent.lifecycle",
+  },
+  { wireName: "UrlCited", storedType: "URL_CITED", legacyCustomName: "source-url" },
+  {
+    wireName: "DocumentCited",
+    storedType: "DOCUMENT_CITED",
+    legacyCustomName: "source-document",
+  },
+  { wireName: "FileAttached", storedType: "FILE_ATTACHED", legacyCustomName: "file" },
+] as const satisfies readonly NativeRunEventDefinition[];
+
+type NativeRunEventEntry = (typeof NATIVE_RUN_EVENTS)[number];
+
+/** AG-UI wire name of a native run event. */
+export type NativeRunEventWireName = NativeRunEventEntry["wireName"];
+
+/** Durable record type of a native run event. */
+export type NativeRunEventStoredType = NativeRunEventEntry["storedType"];
+
+/** Custom event name a native run event replaces. */
+export type NativeRunEventLegacyName = NativeRunEventEntry["legacyCustomName"];
+
+/**
+ * Stored types keyed by the camelCase name this repository's run event tables
+ * use. `agUiSseEventTypes` and `conversationRunEventTypes` spread this object
+ * so a new native type is declared in `NATIVE_RUN_EVENTS` and here, and
+ * nowhere else.
+ *
+ * Written out rather than derived by case-converting `NATIVE_RUN_EVENTS`: a
+ * derived object loses its literal key types, and the two tables that spread it
+ * are consumed as `agUiSseEventTypes.toolCallStatusChanged`, which must stay a
+ * checked property. The first case in this module's test pins the values to the
+ * list in order, so the two cannot drift apart silently.
+ */
+export const nativeRunEventTypes = {
+  toolCallStatusChanged: "TOOL_CALL_STATUS_CHANGED",
+  inputRequestCreated: "INPUT_REQUEST_CREATED",
+  inputRequestUpdated: "INPUT_REQUEST_UPDATED",
+  childRunStatusChanged: "CHILD_RUN_STATUS_CHANGED",
+  urlCited: "URL_CITED",
+  documentCited: "DOCUMENT_CITED",
+  fileAttached: "FILE_ATTACHED",
+} as const;
+
+/** Stored type for each native wire name, for SSE readers. */
+export const nativeRunEventStoredTypesByWireName: ReadonlyMap<string, NativeRunEventStoredType> =
+  new Map(NATIVE_RUN_EVENTS.map((entry) => [entry.wireName, entry.storedType]));
+
+const NATIVE_LEGACY_NAMES: ReadonlySet<string> = new Set(
+  NATIVE_RUN_EVENTS.map((entry) => entry.legacyCustomName),
+);
+
+/** Reports whether a custom event name has a native replacement. */
+export function isNativeRunEventName(name: string): name is NativeRunEventLegacyName {
+  return NATIVE_LEGACY_NAMES.has(name);
+}
+
+/** Live SSE frame: the AG-UI wire name and its payload. */
+export interface NativeRunEventLiveShape {
+  event: NativeRunEventWireName;
+  payload: Record<string, unknown>;
+}
+
+/** Durable record: the same payload carrying its stored type. */
+export type NativeRunEventDurableShape = Record<string, unknown> & {
+  type: NativeRunEventStoredType;
+};
+
+/** The two emission shapes built from one payload. */
+export interface NativeRunEventFrame {
+  live: NativeRunEventLiveShape;
+  durable: NativeRunEventDurableShape;
+}
+
+const TOOL_CALL_STATUS_CHANGED = NATIVE_RUN_EVENTS[0];
+const INPUT_REQUEST_CREATED = NATIVE_RUN_EVENTS[1];
+const INPUT_REQUEST_UPDATED = NATIVE_RUN_EVENTS[2];
+const CHILD_RUN_STATUS_CHANGED = NATIVE_RUN_EVENTS[3];
+const URL_CITED = NATIVE_RUN_EVENTS[4];
+const DOCUMENT_CITED = NATIVE_RUN_EVENTS[5];
+const FILE_ATTACHED = NATIVE_RUN_EVENTS[6];
+
+// `type` is written last so a payload that still carries a chunk type can
+// never win over the stored type. No builder passes one through.
+function toFrame(
+  definition: NativeRunEventEntry,
+  payload: Record<string, unknown>,
+): NativeRunEventFrame {
+  return {
+    live: { event: definition.wireName, payload },
+    durable: { ...payload, type: definition.storedType },
+  };
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+/** Fields the tool input status telemetry carries into a status change. */
+export interface ToolCallStatusChangedInput {
+  toolCallId: string;
+  status: string;
+  toolCallName?: string | null;
+  parentMessageId?: string | null;
+}
+
+/** Build the tool call status change frames. */
+export function buildToolCallStatusChangedEvent(
+  input: ToolCallStatusChangedInput,
+): NativeRunEventFrame {
+  const parentMessageId = readString(input.parentMessageId);
+  return toFrame(TOOL_CALL_STATUS_CHANGED, {
+    toolCallId: input.toolCallId,
+    status: input.status,
+    toolCallName: readString(input.toolCallName),
+    ...(parentMessageId ? { parentMessageId } : {}),
+  });
+}
+
+/** Build the input request lifecycle frames. The action selects the type. */
+export function buildInputRequestLifecycleEvent(input: {
+  action: "created" | "updated";
+  inputRequest: Record<string, unknown>;
+}): NativeRunEventFrame {
+  return toFrame(
+    input.action === "created" ? INPUT_REQUEST_CREATED : INPUT_REQUEST_UPDATED,
+    { inputRequest: input.inputRequest },
+  );
+}
+
+/**
+ * The child run lifecycle value. The index signature is deliberate: the value
+ * is carried through unchanged, the way the API projector carries it, so a
+ * field added to the lifecycle schema reaches the payload without a change
+ * here.
+ */
+export type ChildRunStatusChangedInput = {
+  toolCallId: string;
+  childRunId: string;
+  status: string;
+} & Record<string, unknown>;
+
+/** Build the child run status change frames. */
+export function buildChildRunStatusChangedEvent(
+  value: ChildRunStatusChangedInput,
+): NativeRunEventFrame {
+  return toFrame(CHILD_RUN_STATUS_CHANGED, { ...value });
+}
+
+/**
+ * Build the URL citation frames from a `source-url` chunk.
+ *
+ * A chunk with no url yields an empty one, which the API catalog rejects as a
+ * required field. `buildNativeRunEventFrame` guards that case and keeps the
+ * `Custom` wrapper instead; a direct caller must do the same.
+ */
+export function buildUrlCitedEvent(source: Record<string, unknown>): NativeRunEventFrame {
+  const { type: _type, ...rest } = source;
+  const url = readString(rest.url) ?? "";
+  return toFrame(URL_CITED, { ...rest, url, sourceId: readString(rest.sourceId) ?? url });
+}
+
+/**
+ * Build the document citation frames from a `source-document` chunk.
+ *
+ * As with `buildUrlCitedEvent`, a chunk with no media type yields an empty one
+ * that the API catalog rejects. Route through `buildNativeRunEventFrame`, which
+ * guards it, rather than calling this directly with unvalidated input.
+ */
+export function buildDocumentCitedEvent(source: Record<string, unknown>): NativeRunEventFrame {
+  const { type: _type, ...rest } = source;
+  const mediaType = readString(rest.mediaType) ?? "";
+  return toFrame(DOCUMENT_CITED, {
+    ...rest,
+    mediaType,
+    sourceId: readString(rest.sourceId) ?? mediaType,
+  });
+}
+
+/**
+ * Build the file attachment frames from a `file` chunk.
+ *
+ * The caller decides whether the chunk is a plain file: `buildNativeRunEventFrame`
+ * rejects a `file-change` value, which the API projects to `FILES_CHANGED`.
+ */
+export function buildFileAttachedEvent(source: Record<string, unknown>): NativeRunEventFrame {
+  const { type: _type, ...rest } = source;
+  return toFrame(FILE_ATTACHED, { ...rest, mediaType: readString(rest.mediaType) ?? "" });
+}
+
+/** Routing input for one custom event name and its value. */
+export interface NativeRunEventRoutingInput {
+  name: string;
+  value: unknown;
+  parentMessageId?: string | null;
+}
+
+/**
+ * Build the native frames for a legacy custom name, or null when the name has
+ * no native replacement or the value cannot be read as its payload. A null
+ * return is the caller's signal to keep the `Custom` wrapper, which is how
+ * state snapshots, state deltas, and unknown names stay custom.
+ */
+export function buildNativeRunEventFrame(
+  input: NativeRunEventRoutingInput,
+): NativeRunEventFrame | null {
+  const record = readRecord(input.value);
+  if (!record) return null;
+
+  switch (input.name) {
+    case "tool-call-status": {
+      const toolCallId = readString(record.toolCallId);
+      const status = readString(record.status);
+      if (!toolCallId || !status) return null;
+      return buildToolCallStatusChangedEvent({
+        toolCallId,
+        status,
+        toolCallName: readString(record.toolCallName),
+        parentMessageId: input.parentMessageId ?? readString(record.parentMessageId),
+      });
+    }
+    case "veryfront.input_request.lifecycle": {
+      const action = record.action;
+      const inputRequest = readRecord(record.inputRequest);
+      if (action !== "created" && action !== "updated") return null;
+      if (!inputRequest || !readString(inputRequest.id)) return null;
+      return buildInputRequestLifecycleEvent({ action, inputRequest });
+    }
+    case "veryfront.invoke_agent.lifecycle": {
+      const toolCallId = readString(record.toolCallId);
+      const childRunId = readString(record.childRunId);
+      const status = readString(record.status);
+      if (!toolCallId || !childRunId || !status) return null;
+      return buildChildRunStatusChangedEvent({ ...record, toolCallId, childRunId, status });
+    }
+    case "source-url":
+      return readString(record.url) ? buildUrlCitedEvent(record) : null;
+    case "source-document":
+      return readString(record.mediaType) ? buildDocumentCitedEvent(record) : null;
+    case "file":
+      // The API projector routes a `file-change` value to FILES_CHANGED and
+      // quarantines any other type, so a value that is not a plain file must
+      // not become FileAttached here either. Nothing writes `file-change` in
+      // this runtime today; the guard keeps the two sides twins anyway.
+      return (record.type === "file" || record.type === undefined) &&
+          readString(record.mediaType)
+        ? buildFileAttachedEvent(record)
+        : null;
+    default:
+      return null;
+  }
+}

--- a/src/agent/ag-ui/native-run-events.ts
+++ b/src/agent/ag-ui/native-run-events.ts
@@ -93,6 +93,20 @@ export function isNativeRunEventName(name: string): name is NativeRunEventLegacy
   return NATIVE_LEGACY_NAMES.has(name);
 }
 
+const NATIVE_STORED_TYPES: ReadonlySet<string> = new Set(
+  NATIVE_RUN_EVENTS.map((entry) => entry.storedType),
+);
+
+/**
+ * Reports whether a durable event's `type` is one of the seven native record
+ * types, each of which carries API-catalog-required fields beyond `type`.
+ * Unlike `CUSTOM`, a native type cannot be summarized down to a generic
+ * `{ type, note, summary }` shape without failing that validation.
+ */
+export function isNativeRunEventStoredType(type: string): type is NativeRunEventStoredType {
+  return NATIVE_STORED_TYPES.has(type);
+}
+
 /** Live SSE frame: the AG-UI wire name and its payload. */
 export interface NativeRunEventLiveShape {
   event: NativeRunEventWireName;
@@ -140,8 +154,15 @@ function readRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-/** Fields the tool input status telemetry carries into a status change. */
-export interface ToolCallStatusChangedInput {
+/**
+ * Fields the tool input status telemetry carries into a status change. The
+ * index signature lets a legacy `tool-call-status` custom value's other
+ * fields (`arguments`, `result`, `error`, `exitCode`, and the like) ride
+ * through unchanged, the way `ChildRunStatusChangedInput` carries its value
+ * through -- `applyToolCallStatusEvent` in `src/eval/agent-service.ts` still
+ * reads those fields from this event.
+ */
+export interface ToolCallStatusChangedInput extends Record<string, unknown> {
   toolCallId: string;
   status: string;
   toolCallName?: string | null;
@@ -152,12 +173,14 @@ export interface ToolCallStatusChangedInput {
 export function buildToolCallStatusChangedEvent(
   input: ToolCallStatusChangedInput,
 ): NativeRunEventFrame {
-  const parentMessageId = readString(input.parentMessageId);
+  const { toolCallId, status, toolCallName, parentMessageId, ...rest } = input;
+  const readParentMessageId = readString(parentMessageId);
   return toFrame(TOOL_CALL_STATUS_CHANGED, {
-    toolCallId: input.toolCallId,
-    status: input.status,
-    toolCallName: readString(input.toolCallName),
-    ...(parentMessageId ? { parentMessageId } : {}),
+    ...rest,
+    toolCallId,
+    status,
+    toolCallName: readString(toolCallName),
+    ...(readParentMessageId ? { parentMessageId: readParentMessageId } : {}),
   });
 }
 
@@ -257,6 +280,7 @@ export function buildNativeRunEventFrame(
       const status = readString(record.status);
       if (!toolCallId || !status) return null;
       return buildToolCallStatusChangedEvent({
+        ...record,
         toolCallId,
         status,
         toolCallName: readString(record.toolCallName),

--- a/src/agent/ag-ui/native-run-events.ts
+++ b/src/agent/ag-ui/native-run-events.ts
@@ -88,7 +88,12 @@ const NATIVE_LEGACY_NAMES: ReadonlySet<string> = new Set(
   NATIVE_RUN_EVENTS.map((entry) => entry.legacyCustomName),
 );
 
-/** Reports whether a custom event name has a native replacement. */
+/**
+ * Reports whether a custom event name has a native replacement. Every
+ * routing decision in this module goes through `buildNativeRunEventFrame`
+ * returning null instead of calling this directly; it is exported for other
+ * consumers of this module that need the same check without building a frame.
+ */
 export function isNativeRunEventName(name: string): name is NativeRunEventLegacyName {
   return NATIVE_LEGACY_NAMES.has(name);
 }
@@ -134,13 +139,23 @@ const FILE_ATTACHED = NATIVE_RUN_EVENTS[6];
 
 // `type` is written last so a payload that still carries a chunk type can
 // never win over the stored type. No builder passes one through.
+//
+// `durablePayload` defaults to `livePayload` and only the three citation/file
+// builders pass a distinct one: the API's batch append route rejects an
+// empty-string `title`/`filename`/`url` outright (I1), so those builders drop
+// it from the durable record, but the chat decoder in src/chat/ag-ui.ts uses
+// a string `title` (DocumentCited) or `url` (FileAttached) -- empty string
+// included -- as its gate for rendering the citation/attachment at all, so
+// the live wire frame must keep the field exactly as the legacy `Custom`
+// wrapper carried it.
 function toFrame(
   definition: NativeRunEventEntry,
-  payload: Record<string, unknown>,
+  livePayload: Record<string, unknown>,
+  durablePayload: Record<string, unknown> = livePayload,
 ): NativeRunEventFrame {
   return {
-    live: { event: definition.wireName, payload },
-    durable: { ...payload, type: definition.storedType },
+    live: { event: definition.wireName, payload: livePayload },
+    durable: { ...durablePayload, type: definition.storedType },
   };
 }
 
@@ -152,6 +167,28 @@ function readRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null;
+}
+
+/**
+ * Drop the listed keys from `rest` when their value is an empty string, for
+ * the durable payload only (see `toFrame`). The API catalog declares
+ * `title`/`filename`/`url` as `z.string().min(1).optional()`, so an empty
+ * string is a hard validation failure on the batch append route while an
+ * absent key, `null`, or any other value is not -- only the empty-string
+ * case needs dropping, never passed through like the required fields' own
+ * `readString` guard.
+ */
+function omitEmptyStrings(
+  rest: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...rest };
+  for (const key of keys) {
+    if (result[key] === "") {
+      delete result[key];
+    }
+  }
+  return result;
 }
 
 /**
@@ -220,11 +257,17 @@ export function buildChildRunStatusChangedEvent(
  * A chunk with no url yields an empty one, which the API catalog rejects as a
  * required field. `buildNativeRunEventFrame` guards that case and keeps the
  * `Custom` wrapper instead; a direct caller must do the same.
+ *
+ * `title` reaches the live wire frame exactly as the chunk carried it,
+ * empty string included, since the chat decoder's UrlCited case renders the
+ * citation regardless of title; the durable record drops an empty one
+ * instead, since the API catalog rejects it there.
  */
 export function buildUrlCitedEvent(source: Record<string, unknown>): NativeRunEventFrame {
   const { type: _type, ...rest } = source;
   const url = readString(rest.url) ?? "";
-  return toFrame(URL_CITED, { ...rest, url, sourceId: readString(rest.sourceId) ?? url });
+  const payload = { ...rest, url, sourceId: readString(rest.sourceId) ?? url };
+  return toFrame(URL_CITED, payload, omitEmptyStrings(payload, ["title"]));
 }
 
 /**
@@ -233,15 +276,26 @@ export function buildUrlCitedEvent(source: Record<string, unknown>): NativeRunEv
  * As with `buildUrlCitedEvent`, a chunk with no media type yields an empty one
  * that the API catalog rejects. Route through `buildNativeRunEventFrame`, which
  * guards it, rather than calling this directly with unvalidated input.
+ *
+ * `title` is never dropped, in either shape, unlike this event's own
+ * `filename` or `buildUrlCitedEvent`'s `title`: `ChatSourceDocumentUiPart.title`
+ * is a required chat UI field (not optional like its siblings), so the chat
+ * decoder uses a string title as its gate for rendering the citation at all.
+ * An empty title falls back to the source id instead -- the same value this
+ * builder already falls back to when the chunk has no source id of its own
+ * -- so the citation always has a renderable, API-valid title in both the
+ * live frame and the durable record, with nothing for a later replay to
+ * restore. `filename` reaches the live wire frame exactly as the chunk
+ * carried it, empty string included, and the durable record drops an empty
+ * one, since the API catalog rejects it there and the chat decoder never
+ * gates rendering on it.
  */
 export function buildDocumentCitedEvent(source: Record<string, unknown>): NativeRunEventFrame {
   const { type: _type, ...rest } = source;
   const mediaType = readString(rest.mediaType) ?? "";
-  return toFrame(DOCUMENT_CITED, {
-    ...rest,
-    mediaType,
-    sourceId: readString(rest.sourceId) ?? mediaType,
-  });
+  const sourceId = readString(rest.sourceId) ?? mediaType;
+  const payload = { ...rest, mediaType, sourceId, title: readString(rest.title) ?? sourceId };
+  return toFrame(DOCUMENT_CITED, payload, omitEmptyStrings(payload, ["filename"]));
 }
 
 /**
@@ -249,10 +303,26 @@ export function buildDocumentCitedEvent(source: Record<string, unknown>): Native
  *
  * The caller decides whether the chunk is a plain file: `buildNativeRunEventFrame`
  * rejects a `file-change` value, which the API projects to `FILES_CHANGED`.
+ *
+ * `url`/`filename` reach the live wire frame exactly as the chunk carried
+ * them, empty string included: the chat decoder's FileAttached case uses a
+ * string `url` -- empty string included -- as its gate for rendering the
+ * attachment at all, so dropping an empty one from the live frame would make
+ * the attachment disappear instead of merely losing its url. The durable
+ * record drops an empty url or filename instead, since the API catalog
+ * rejects either there.
+ *
+ * Unlike `buildDocumentCitedEvent`'s title, `url` has no safe non-empty
+ * fallback here -- a placeholder url would be an actively misleading,
+ * possibly broken link -- so a chunk whose url was empty is, once stored,
+ * indistinguishable on replay from one that never had a url at all: both
+ * read back unrenderable. Known, accepted gap; the live frame still renders
+ * it correctly the first time.
  */
 export function buildFileAttachedEvent(source: Record<string, unknown>): NativeRunEventFrame {
   const { type: _type, ...rest } = source;
-  return toFrame(FILE_ATTACHED, { ...rest, mediaType: readString(rest.mediaType) ?? "" });
+  const payload = { ...rest, mediaType: readString(rest.mediaType) ?? "" };
+  return toFrame(FILE_ATTACHED, payload, omitEmptyStrings(payload, ["filename", "url"]));
 }
 
 /** Routing input for one custom event name and its value. */

--- a/src/agent/ag-ui/native-run-events.ts
+++ b/src/agent/ag-ui/native-run-events.ts
@@ -137,8 +137,8 @@ const URL_CITED = NATIVE_RUN_EVENTS[4];
 const DOCUMENT_CITED = NATIVE_RUN_EVENTS[5];
 const FILE_ATTACHED = NATIVE_RUN_EVENTS[6];
 
-// Strip the reserved `type` field before publication so both readers use
-// the native event type, including when an open input record carries a chunk type.
+// Keep application fields from overriding the native type or transport timing
+// when an open custom value becomes a flat native payload.
 //
 // One payload feeds both shapes: the live wire frame is not just this
 // repo's own chat client either, the API ingests the same SSE frame and
@@ -151,7 +151,7 @@ function toFrame(
   definition: NativeRunEventEntry,
   payload: Record<string, unknown>,
 ): NativeRunEventFrame {
-  const { type: _type, ...nativePayload } = payload;
+  const { type: _type, elapsedMs: _elapsedMs, emittedAt: _emittedAt, ...nativePayload } = payload;
   return {
     live: { event: definition.wireName, payload: nativePayload },
     durable: { ...nativePayload, type: definition.storedType },

--- a/src/agent/ag-ui/sse-parser.test.ts
+++ b/src/agent/ag-ui/sse-parser.test.ts
@@ -129,4 +129,23 @@ describe("agent/ag-ui-sse-parser", () => {
     );
     assertEquals(run.responseStatus, 502, "the non-OK status must still be recorded");
   });
+
+  it("normalizes native run event frames to their stored types", async () => {
+    const run = await parseAgUiSseResponse(
+      createSseResponse([
+        'id: 1\nevent: ToolCallStatusChanged\ndata: {"toolCallId":"tool-1",' +
+        '"toolCallName":"create_file","status":"pending_input"}\n\n',
+        'id: 2\nevent: UrlCited\ndata: {"sourceId":"web-1","url":"https://example.com/a"}\n\n',
+        'id: 3\nevent: ChildRunStatusChanged\ndata: {"toolCallId":"t","childRunId":"r",' +
+        '"status":"running"}\n\n',
+      ]),
+    );
+
+    assertEquals(run.eventTypes, [
+      "TOOL_CALL_STATUS_CHANGED",
+      "URL_CITED",
+      "CHILD_RUN_STATUS_CHANGED",
+    ]);
+    assertEquals(run.events[0]?.toolCallName, "create_file");
+  });
 });

--- a/src/agent/ag-ui/sse-parser.ts
+++ b/src/agent/ag-ui/sse-parser.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "#veryfront/chat/conversation.ts";
 import { safeJsonParse } from "#veryfront/chat/provider-errors.ts";
+import { nativeRunEventStoredTypesByWireName, nativeRunEventTypes } from "./native-run-events.ts";
 
 /** AG-UI runtime event type constants normalized from legacy SSE event names. */
 export const agUiSseEventTypes = {
@@ -21,6 +22,7 @@ export const agUiSseEventTypes = {
   stepFinished: "STEP_FINISHED",
   runError: "RUN_ERROR",
   runFinished: "RUN_FINISHED",
+  ...nativeRunEventTypes,
 } as const;
 
 /** Normalized AG-UI runtime event type value. */
@@ -190,8 +192,10 @@ function coerceWireEvent(
       return { type: agUiSseEventTypes.runError, ...payload };
     case "RunFinished":
       return { type: agUiSseEventTypes.runFinished, ...payload };
-    default:
-      return { type: eventName, ...payload };
+    default: {
+      const nativeType = nativeRunEventStoredTypesByWireName.get(eventName);
+      return nativeType ? { type: nativeType, ...payload } : { type: eventName, ...payload };
+    }
   }
 }
 

--- a/src/agent/child-run/invoke-agent-child-runs.test.ts
+++ b/src/agent/child-run/invoke-agent-child-runs.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  buildInvokeAgentChildRunLifecycleCustomEvent,
   buildInvokeAgentChildRunProgressEvents,
   buildInvokeAgentChildRunStateDelta,
   publishInvokeAgentChildRunProgress,
@@ -117,22 +118,31 @@ describe("agent/invoke-agent-child-runs", () => {
         ],
       },
       {
-        type: "CUSTOM",
-        name: "veryfront.invoke_agent.lifecycle",
-        value: {
-          toolCallId: "tool/call~1",
-          childConversationId: CHILD_CONVERSATION_ID,
-          childRunId: "run_child_1",
-          childMessageId: CHILD_MESSAGE_ID,
-          childAgentId: "researcher",
-          description: "Inspect logs",
-          status: "pending",
-          sourceTargetKind: "project",
-          runtimeTargetKind: "main_branch",
-          targetBranchId: null,
-        },
+        toolCallId: "tool/call~1",
+        childConversationId: CHILD_CONVERSATION_ID,
+        childRunId: "run_child_1",
+        childMessageId: CHILD_MESSAGE_ID,
+        childAgentId: "researcher",
+        description: "Inspect logs",
+        status: "pending",
+        sourceTargetKind: "project",
+        runtimeTargetKind: "main_branch",
+        targetBranchId: null,
+        type: "CHILD_RUN_STATUS_CHANGED",
       },
     ]);
+  });
+
+  it("keeps the state delta paired with the native status record", () => {
+    const events = buildInvokeAgentChildRunProgressEvents({ ...BASE_INPUT, status: "completed" });
+
+    assertEquals(events.length, 2);
+    assertEquals(events[0]?.type, "STATE_DELTA");
+    assertEquals(events[1]?.type, "CHILD_RUN_STATUS_CHANGED");
+    assertEquals(
+      buildInvokeAgentChildRunLifecycleCustomEvent({ ...BASE_INPUT, status: "completed" }),
+      events[1],
+    );
   });
 
   it("uses a shared publisher when provided", async () => {

--- a/src/agent/child-run/invoke-agent-child-runs.test.ts
+++ b/src/agent/child-run/invoke-agent-child-runs.test.ts
@@ -5,8 +5,12 @@ import {
   buildInvokeAgentChildRunLifecycleCustomEvent,
   buildInvokeAgentChildRunProgressEvents,
   buildInvokeAgentChildRunStateDelta,
+  getInvokeAgentChildRunLifecycleCustomEventSchema,
+  InvokeAgentChildRunLifecycleCustomEventSchema,
   publishInvokeAgentChildRunProgress,
 } from "./invoke-agent-child-runs.ts";
+
+import { prepareConversationRunExternalEvents } from "../conversation/run-event-preparation.ts";
 
 const API_URL = "https://api.example.com";
 const AUTH_TOKEN = "token-123";
@@ -118,31 +122,49 @@ describe("agent/invoke-agent-child-runs", () => {
         ],
       },
       {
-        toolCallId: "tool/call~1",
-        childConversationId: CHILD_CONVERSATION_ID,
-        childRunId: "run_child_1",
-        childMessageId: CHILD_MESSAGE_ID,
-        childAgentId: "researcher",
-        description: "Inspect logs",
-        status: "pending",
-        sourceTargetKind: "project",
-        runtimeTargetKind: "main_branch",
-        targetBranchId: null,
-        type: "CHILD_RUN_STATUS_CHANGED",
+        type: "CUSTOM",
+        name: "veryfront.invoke_agent.lifecycle",
+        value: BASE_INPUT,
       },
     ]);
   });
 
-  it("keeps the state delta paired with the native status record", () => {
+  it("preserves the public Custom event builder and schema contract", () => {
     const events = buildInvokeAgentChildRunProgressEvents({ ...BASE_INPUT, status: "completed" });
 
     assertEquals(events.length, 2);
     assertEquals(events[0]?.type, "STATE_DELTA");
-    assertEquals(events[1]?.type, "CHILD_RUN_STATUS_CHANGED");
+    assertEquals(events[1]?.type, "CUSTOM");
+    const expected = {
+      type: "CUSTOM",
+      name: "veryfront.invoke_agent.lifecycle",
+      value: { ...BASE_INPUT, status: "completed" },
+    } as const;
+    assertEquals(events[1], expected);
+    assertEquals(getInvokeAgentChildRunLifecycleCustomEventSchema().parse(expected), expected);
+    assertEquals(InvokeAgentChildRunLifecycleCustomEventSchema.parse(expected), expected);
     assertEquals(
       buildInvokeAgentChildRunLifecycleCustomEvent({ ...BASE_INPUT, status: "completed" }),
       events[1],
     );
+  });
+
+  it("converts a public child-run event to native form at external publication", () => {
+    const event = {
+      type: "CUSTOM",
+      name: "veryfront.invoke_agent.lifecycle",
+      value: BASE_INPUT,
+      elapsedMs: 12,
+      emittedAt: "2026-09-09T12:00:00.000Z",
+    };
+    assertEquals(prepareConversationRunExternalEvents([event]), [{
+      ...BASE_INPUT,
+      type: "CHILD_RUN_STATUS_CHANGED",
+      elapsedMs: 12,
+      emittedAt: event.emittedAt,
+    }]);
+    assertEquals(event.type, "CUSTOM");
+    assertEquals(event.value, BASE_INPUT);
   });
 
   it("uses a shared publisher when provided", async () => {
@@ -201,7 +223,10 @@ describe("agent/invoke-agent-child-runs", () => {
     assertEquals(JSON.parse(String(calls[0]?.[1]?.body)), {
       expected_previous_event_id: 3,
       expected_previous_external_event_sequence: 4,
-      events: [...buildInvokeAgentChildRunProgressEvents(BASE_INPUT)],
+      events: [buildInvokeAgentChildRunStateDelta(BASE_INPUT), {
+        ...BASE_INPUT,
+        type: "CHILD_RUN_STATUS_CHANGED",
+      }],
     });
   });
 

--- a/src/agent/child-run/invoke-agent-child-runs.ts
+++ b/src/agent/child-run/invoke-agent-child-runs.ts
@@ -1,10 +1,11 @@
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
-import { buildChildRunStatusChangedEvent } from "#veryfront/agent/ag-ui/native-run-events.ts";
 import {
   appendConversationRunEvents,
   isIgnorableConversationRunAppendError,
 } from "../conversation/durable.ts";
+
+const AG_UI_CUSTOM_EVENT_TYPE = "CUSTOM";
 
 /** Zod schema for get invoke agent child run lifecycle value. */
 export const getInvokeAgentChildRunLifecycleValueSchema = defineSchema((v) =>
@@ -63,15 +64,15 @@ export type InvokeAgentChildRunStateDelta = InferSchema<
   ReturnType<typeof getInvokeAgentChildRunStateDeltaSchema>
 >;
 
-// legacy: removed in Phase F — rename to getInvokeAgentChildRunStatusChangedEventSchema at the cutover.
 /** Zod schema for get invoke agent child run lifecycle custom event. */
 export const getInvokeAgentChildRunLifecycleCustomEventSchema = defineSchema((v) =>
   v.object({
-    type: v.literal("CHILD_RUN_STATUS_CHANGED"),
-  }).merge(getInvokeAgentChildRunLifecycleValueSchema())
+    type: v.literal(AG_UI_CUSTOM_EVENT_TYPE),
+    name: v.literal("veryfront.invoke_agent.lifecycle"),
+    value: getInvokeAgentChildRunLifecycleValueSchema(),
+  })
 );
 
-// legacy: removed in Phase F — rename to InvokeAgentChildRunStatusChangedEventSchema at the cutover.
 /** Schema for invoke agent child run lifecycle custom event.
  * @deprecated Use getInvokeAgentChildRunLifecycleCustomEventSchema()
  */
@@ -79,7 +80,6 @@ export const InvokeAgentChildRunLifecycleCustomEventSchema = lazySchema(
   getInvokeAgentChildRunLifecycleCustomEventSchema,
 );
 
-// legacy: removed in Phase F — rename to InvokeAgentChildRunStatusChangedEvent at the cutover.
 /** Event emitted for invoke agent child run lifecycle custom. */
 export type InvokeAgentChildRunLifecycleCustomEvent = InferSchema<
   ReturnType<typeof getInvokeAgentChildRunLifecycleCustomEventSchema>
@@ -144,15 +144,15 @@ export function buildInvokeAgentChildRunStateDelta(
   });
 }
 
-// legacy: removed in Phase F — rename to buildInvokeAgentChildRunStatusChangedEvent at the cutover.
 /** Event emitted for build invoke agent child run lifecycle custom. */
 export function buildInvokeAgentChildRunLifecycleCustomEvent(
   input: InvokeAgentChildRunProgressInput,
 ): InvokeAgentChildRunLifecycleCustomEvent {
-  const value = buildInvokeAgentChildRunLifecycleValue(input);
-  return getInvokeAgentChildRunLifecycleCustomEventSchema().parse(
-    buildChildRunStatusChangedEvent({ ...value }).durable,
-  );
+  return getInvokeAgentChildRunLifecycleCustomEventSchema().parse({
+    type: AG_UI_CUSTOM_EVENT_TYPE,
+    name: "veryfront.invoke_agent.lifecycle",
+    value: buildInvokeAgentChildRunLifecycleValue(input),
+  });
 }
 
 /** Builds invoke agent child run progress events. */

--- a/src/agent/child-run/invoke-agent-child-runs.ts
+++ b/src/agent/child-run/invoke-agent-child-runs.ts
@@ -1,11 +1,10 @@
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
+import { buildChildRunStatusChangedEvent } from "#veryfront/agent/ag-ui/native-run-events.ts";
 import {
   appendConversationRunEvents,
   isIgnorableConversationRunAppendError,
 } from "../conversation/durable.ts";
-
-const AG_UI_CUSTOM_EVENT_TYPE = "CUSTOM";
 
 /** Zod schema for get invoke agent child run lifecycle value. */
 export const getInvokeAgentChildRunLifecycleValueSchema = defineSchema((v) =>
@@ -64,15 +63,15 @@ export type InvokeAgentChildRunStateDelta = InferSchema<
   ReturnType<typeof getInvokeAgentChildRunStateDeltaSchema>
 >;
 
+// legacy: removed in Phase F — rename to getInvokeAgentChildRunStatusChangedEventSchema at the cutover.
 /** Zod schema for get invoke agent child run lifecycle custom event. */
 export const getInvokeAgentChildRunLifecycleCustomEventSchema = defineSchema((v) =>
   v.object({
-    type: v.literal(AG_UI_CUSTOM_EVENT_TYPE),
-    name: v.literal("veryfront.invoke_agent.lifecycle"),
-    value: getInvokeAgentChildRunLifecycleValueSchema(),
-  })
+    type: v.literal("CHILD_RUN_STATUS_CHANGED"),
+  }).merge(getInvokeAgentChildRunLifecycleValueSchema())
 );
 
+// legacy: removed in Phase F — rename to InvokeAgentChildRunStatusChangedEventSchema at the cutover.
 /** Schema for invoke agent child run lifecycle custom event.
  * @deprecated Use getInvokeAgentChildRunLifecycleCustomEventSchema()
  */
@@ -80,6 +79,7 @@ export const InvokeAgentChildRunLifecycleCustomEventSchema = lazySchema(
   getInvokeAgentChildRunLifecycleCustomEventSchema,
 );
 
+// legacy: removed in Phase F — rename to InvokeAgentChildRunStatusChangedEvent at the cutover.
 /** Event emitted for invoke agent child run lifecycle custom. */
 export type InvokeAgentChildRunLifecycleCustomEvent = InferSchema<
   ReturnType<typeof getInvokeAgentChildRunLifecycleCustomEventSchema>
@@ -144,15 +144,15 @@ export function buildInvokeAgentChildRunStateDelta(
   });
 }
 
+// legacy: removed in Phase F — rename to buildInvokeAgentChildRunStatusChangedEvent at the cutover.
 /** Event emitted for build invoke agent child run lifecycle custom. */
 export function buildInvokeAgentChildRunLifecycleCustomEvent(
   input: InvokeAgentChildRunProgressInput,
 ): InvokeAgentChildRunLifecycleCustomEvent {
-  return getInvokeAgentChildRunLifecycleCustomEventSchema().parse({
-    type: AG_UI_CUSTOM_EVENT_TYPE,
-    name: "veryfront.invoke_agent.lifecycle",
-    value: buildInvokeAgentChildRunLifecycleValue(input),
-  });
+  const value = buildInvokeAgentChildRunLifecycleValue(input);
+  return getInvokeAgentChildRunLifecycleCustomEventSchema().parse(
+    buildChildRunStatusChangedEvent({ ...value }).durable,
+  );
 }
 
 /** Builds invoke agent child run progress events. */

--- a/src/agent/conversation/legacy-run-read-adapter.test.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.test.ts
@@ -1642,8 +1642,8 @@ describe("conversation run lifecycle read adapter", () => {
     // reader derived from the stored type. No native builder writes these
     // fields today, but a corrupted or hand-built durable record could still
     // carry one, so the reader must not trust it over its own derivation --
-    // the chat decoder at ag-ui.ts:1039 makes the same call for the wire
-    // payload's `type` field.
+    // the citation/file case in the same reader makes the same call for the
+    // stored `type` field.
     it("keeps the derived action instead of one smuggled inside a corrupted INPUT_REQUEST_CREATED value", () => {
       const frames = customFramesFor(2, {
         type: "INPUT_REQUEST_CREATED",
@@ -1678,12 +1678,13 @@ describe("conversation run lifecycle read adapter", () => {
 
     // Regression guard: a DOCUMENT_CITED chunk built with an empty title has
     // no title key at all in the durable record (native-run-events.ts's
-    // omitEmptyStrings drops it from the one payload both shapes share, I1),
-    // and there is nothing for this reader to restore -- the replayed CUSTOM
-    // twin must keep it just as absent, matching the live frame the encoder
-    // produced. Rendering a fallback title for a citation with no title is
-    // the chat decoder's job (src/chat/ag-ui.ts), exercised there against
-    // both the live and replayed shapes since they are now identical.
+    // omitInvalidOptionalStrings drops it from the one payload both shapes
+    // share, I1), and there is nothing for this reader to restore -- the
+    // replayed CUSTOM twin must keep it just as absent, matching the live
+    // frame the encoder produced. Rendering a fallback title for a citation
+    // with no title is the chat decoder's job (src/chat/ag-ui.ts), exercised
+    // there against both the live and replayed shapes since they are now
+    // identical.
     it("replays a DOCUMENT_CITED citation built with an empty title with no title key, matching the live frame", () => {
       const durable = buildDocumentCitedEvent({
         type: "source-document",

--- a/src/agent/conversation/legacy-run-read-adapter.test.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.test.ts
@@ -13,6 +13,14 @@ import { createLifecycleRunEventAdapter } from "./lifecycle-run-event-adapter.ts
 import { readConversationRunLifecycleFrames } from "./legacy-run-read-adapter.ts";
 import { normalizeConversationRunEvents } from "./run-event-normalization.ts";
 import { type ConversationRunEvent, normalizeEncodedConversationRunEvents } from "./run-events.ts";
+import {
+  buildChildRunStatusChangedEvent,
+  buildDocumentCitedEvent,
+  buildFileAttachedEvent,
+  buildInputRequestLifecycleEvent,
+  buildToolCallStatusChangedEvent,
+  buildUrlCitedEvent,
+} from "../ag-ui/native-run-events.ts";
 
 function frames(
   entries: readonly {
@@ -1426,5 +1434,180 @@ describe("conversation run lifecycle read adapter", () => {
         },
       }],
     );
+  });
+
+  describe("native stored types read back as their CUSTOM twin", () => {
+    function v2Envelope(sequence: number, key: string) {
+      return { stream_protocol_version: 2, logical_sequence: sequence, idempotency_key: key };
+    }
+
+    function customFramesFor(
+      streamProtocolVersion: 1 | 2,
+      event: Record<string, unknown>,
+    ) {
+      const result = readConversationRunLifecycleFrames({
+        streamProtocolVersion,
+        events: [event],
+      });
+      assertEquals(result.status, "ok");
+      if (result.status !== "ok") return [];
+      return result.frames
+        .filter((frame) => frame.class === "semantic" && frame.event.type === "custom")
+        .map((frame) => frame.event);
+    }
+
+    const cases: Array<{
+      description: string;
+      native: Record<string, unknown>;
+      customTwin: Record<string, unknown>;
+    }> = [
+      {
+        description: "TOOL_CALL_STATUS_CHANGED",
+        native: buildToolCallStatusChangedEvent({
+          toolCallId: "tool-1",
+          status: "completed",
+          toolCallName: "web_search",
+          parentMessageId: "message-1",
+        }).durable,
+        customTwin: {
+          type: "CUSTOM",
+          name: "tool-call-status",
+          value: {
+            toolCallId: "tool-1",
+            status: "completed",
+            toolCallName: "web_search",
+            parentMessageId: "message-1",
+          },
+        },
+      },
+      {
+        description: "INPUT_REQUEST_CREATED",
+        native: buildInputRequestLifecycleEvent({
+          action: "created",
+          inputRequest: { id: "req-1", kind: "form" },
+        }).durable,
+        customTwin: {
+          type: "CUSTOM",
+          name: "veryfront.input_request.lifecycle",
+          value: { action: "created", inputRequest: { id: "req-1", kind: "form" } },
+        },
+      },
+      {
+        description: "INPUT_REQUEST_UPDATED",
+        native: buildInputRequestLifecycleEvent({
+          action: "updated",
+          inputRequest: { id: "req-1", kind: "form" },
+        }).durable,
+        customTwin: {
+          type: "CUSTOM",
+          name: "veryfront.input_request.lifecycle",
+          value: { action: "updated", inputRequest: { id: "req-1", kind: "form" } },
+        },
+      },
+      {
+        description: "CHILD_RUN_STATUS_CHANGED",
+        native: buildChildRunStatusChangedEvent({
+          toolCallId: "tool-2",
+          childRunId: "run-2",
+          status: "running",
+        }).durable,
+        customTwin: {
+          type: "CUSTOM",
+          name: "veryfront.invoke_agent.lifecycle",
+          value: { toolCallId: "tool-2", childRunId: "run-2", status: "running" },
+        },
+      },
+      {
+        description: "URL_CITED",
+        native: buildUrlCitedEvent({
+          type: "source-url",
+          sourceId: "web-1",
+          url: "https://example.com/a",
+          title: "Example",
+        }).durable,
+        customTwin: {
+          type: "CUSTOM",
+          name: "source-url",
+          value: {
+            type: "source-url",
+            sourceId: "web-1",
+            url: "https://example.com/a",
+            title: "Example",
+          },
+        },
+      },
+      {
+        description: "DOCUMENT_CITED",
+        native: buildDocumentCitedEvent({
+          type: "source-document",
+          sourceId: "doc-1",
+          mediaType: "application/pdf",
+          title: "Doc",
+        }).durable,
+        customTwin: {
+          type: "CUSTOM",
+          name: "source-document",
+          value: {
+            type: "source-document",
+            sourceId: "doc-1",
+            mediaType: "application/pdf",
+            title: "Doc",
+          },
+        },
+      },
+      {
+        description: "FILE_ATTACHED",
+        native: buildFileAttachedEvent({
+          type: "file",
+          mediaType: "text/plain",
+          path: "notes.txt",
+        }).durable,
+        customTwin: {
+          type: "CUSTOM",
+          name: "file",
+          value: { type: "file", mediaType: "text/plain", path: "notes.txt" },
+        },
+      },
+    ];
+
+    for (const { description, native, customTwin } of cases) {
+      it(`reads a ${description} durable record as its CUSTOM twin on the version 2 reader`, () => {
+        const nativeFrames = customFramesFor(2, {
+          ...native,
+          ...v2Envelope(1, `native:${description}`),
+        });
+        const twinFrames = customFramesFor(2, {
+          ...customTwin,
+          ...v2Envelope(1, `twin:${description}`),
+        });
+        assertEquals(nativeFrames, twinFrames);
+      });
+    }
+
+    it("reads a URL_CITED durable record as its CUSTOM twin on the version 1 reader", () => {
+      const { native, customTwin } = cases.find((entry) => entry.description === "URL_CITED")!;
+      assertEquals(customFramesFor(1, native), customFramesFor(1, customTwin));
+    });
+
+    it("reads a TOOL_CALL_STATUS_CHANGED durable record as its CUSTOM twin on the version 1 reader", () => {
+      const { native, customTwin } = cases.find((entry) =>
+        entry.description === "TOOL_CALL_STATUS_CHANGED"
+      )!;
+      assertEquals(customFramesFor(1, native), customFramesFor(1, customTwin));
+    });
+
+    it("still rejects an unrelated unknown type for version 2", () => {
+      const result = readConversationRunLifecycleFrames({
+        streamProtocolVersion: 2,
+        events: [{
+          type: "SOME_UNRELATED_UNKNOWN_TYPE",
+          ...v2Envelope(1, "unrelated:1"),
+        }],
+      });
+      assertEquals(result.status, "invalid");
+      if (result.status === "invalid") {
+        assertEquals(result.code, "UNSUPPORTED_DURABLE_EVENT");
+      }
+    });
   });
 });

--- a/src/agent/conversation/legacy-run-read-adapter.test.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.test.ts
@@ -1596,6 +1596,33 @@ describe("conversation run lifecycle read adapter", () => {
       assertEquals(customFramesFor(1, native), customFramesFor(1, customTwin));
     });
 
+    it("strips version 1 timing stamps from the rebuilt CUSTOM twin's value", () => {
+      // ConversationRunEventEncoder.stampElapsed() (run-events.ts), which also
+      // builds this native record in production, stamps elapsedMs/emittedAt
+      // onto every durable event's own top level -- native records included --
+      // whenever it has a real timing anchor. Mirror that shape here rather
+      // than relying on the builder's bare durable output.
+      //
+      // URL_CITED, not TOOL_CALL_STATUS_CHANGED: the version 1 reducer
+      // special-cases a "custom" signal named "tool-call-status"
+      // (reducer.ts's `case "custom":"), turning a "pending_input"/
+      // "streaming_input" status into a telemetry frame and swallowing every
+      // other status without emitting any semantic "custom" frame at all --
+      // so a tool-call-status case here would compare `[]` against `[]` on
+      // both sides and could never catch a value-leak regression.
+      const { native, customTwin } = cases.find((entry) => entry.description === "URL_CITED")!;
+      const stampedNative = { ...native, elapsedMs: 42, emittedAt: 1757400000000 };
+
+      const frames = customFramesFor(1, stampedNative);
+      assertEquals(frames.length > 0, true, "the case must exercise a real semantic custom frame");
+      assertEquals(frames, customFramesFor(1, customTwin));
+      for (const frame of frames) {
+        const data = (frame as { data: unknown }).data as Record<string, unknown>;
+        assertEquals(Object.hasOwn(data, "elapsedMs"), false);
+        assertEquals(Object.hasOwn(data, "emittedAt"), false);
+      }
+    });
+
     it("still rejects an unrelated unknown type for version 2", () => {
       const result = readConversationRunLifecycleFrames({
         streamProtocolVersion: 2,

--- a/src/agent/conversation/legacy-run-read-adapter.test.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.test.ts
@@ -1676,14 +1676,15 @@ describe("conversation run lifecycle read adapter", () => {
       );
     });
 
-    // Regression guard: a DOCUMENT_CITED chunk built with an empty title
-    // must still read back with a renderable (non-empty) title after a
-    // durable round trip, since ChatSourceDocumentUiPart.title is required
-    // at the chat UI type level -- buildDocumentCitedEvent falls back to
-    // sourceId instead of dropping it, so there is nothing for this reader
-    // to restore, and a replayed record renders exactly as the live frame
-    // did.
-    it("replays a DOCUMENT_CITED citation built with an empty title as its sourceId-titled CUSTOM twin", () => {
+    // Regression guard: a DOCUMENT_CITED chunk built with an empty title has
+    // no title key at all in the durable record (native-run-events.ts's
+    // omitEmptyStrings drops it from the one payload both shapes share, I1),
+    // and there is nothing for this reader to restore -- the replayed CUSTOM
+    // twin must keep it just as absent, matching the live frame the encoder
+    // produced. Rendering a fallback title for a citation with no title is
+    // the chat decoder's job (src/chat/ag-ui.ts), exercised there against
+    // both the live and replayed shapes since they are now identical.
+    it("replays a DOCUMENT_CITED citation built with an empty title with no title key, matching the live frame", () => {
       const durable = buildDocumentCitedEvent({
         type: "source-document",
         sourceId: "doc-1",
@@ -1691,15 +1692,19 @@ describe("conversation run lifecycle read adapter", () => {
         title: "",
       }).durable;
       assertEquals(
-        durable.title,
-        "doc-1",
-        "the durable record must fall back to a non-empty title",
+        Object.hasOwn(durable, "title"),
+        false,
+        "the durable record must not carry the empty title",
       );
 
-      const frames = customFramesFor(2, { ...durable, ...v2Envelope(1, "empty-title-fallback") });
+      const frames = customFramesFor(2, { ...durable, ...v2Envelope(1, "empty-title-dropped") });
       assertEquals(frames.length, 1);
       const data = (frames[0] as { data: Record<string, unknown> }).data;
-      assertEquals(data.title, "doc-1", "the replayed CUSTOM twin must keep the fallback title");
+      assertEquals(
+        Object.hasOwn(data, "title"),
+        false,
+        "the replayed CUSTOM twin must not have a title key either",
+      );
     });
   });
 });

--- a/src/agent/conversation/legacy-run-read-adapter.test.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.test.ts
@@ -20,6 +20,7 @@ import {
   buildInputRequestLifecycleEvent,
   buildToolCallStatusChangedEvent,
   buildUrlCitedEvent,
+  NATIVE_RUN_EVENTS,
 } from "../ag-ui/native-run-events.ts";
 
 function frames(
@@ -1569,6 +1570,13 @@ describe("conversation run lifecycle read adapter", () => {
         },
       },
     ];
+
+    it("covers every native type with a legacy reconstruction case", () => {
+      assertEquals(
+        [...new Set(cases.map(({ native }) => native.type))].sort(),
+        NATIVE_RUN_EVENTS.map(({ storedType }) => storedType).sort(),
+      );
+    });
 
     for (const { description, native, customTwin } of cases) {
       it(`reads a ${description} durable record as its CUSTOM twin on the version 2 reader`, () => {

--- a/src/agent/conversation/legacy-run-read-adapter.test.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.test.ts
@@ -1636,5 +1636,70 @@ describe("conversation run lifecycle read adapter", () => {
         assertEquals(result.code, "UNSUPPORTED_DURABLE_EVENT");
       }
     });
+
+    // M5: both twin-reconstruction sites rebuild `{ authoritativeKey, ...value
+    // }`, so a key smuggled inside the stored value wins over the value the
+    // reader derived from the stored type. No native builder writes these
+    // fields today, but a corrupted or hand-built durable record could still
+    // carry one, so the reader must not trust it over its own derivation --
+    // the chat decoder at ag-ui.ts:1039 makes the same call for the wire
+    // payload's `type` field.
+    it("keeps the derived action instead of one smuggled inside a corrupted INPUT_REQUEST_CREATED value", () => {
+      const frames = customFramesFor(2, {
+        type: "INPUT_REQUEST_CREATED",
+        inputRequest: { id: "req-1", kind: "form" },
+        action: "updated",
+        ...v2Envelope(1, "smuggle:action"),
+      });
+      assertEquals(frames.length, 1);
+      const data = (frames[0] as { data: Record<string, unknown> }).data;
+      assertEquals(
+        data.action,
+        "created",
+        "the action derived from the stored INPUT_REQUEST_CREATED type must win over one smuggled inside the stored value",
+      );
+    });
+
+    it("keeps the derived type as the CUSTOM twin's type field for a citation record", () => {
+      const native = buildUrlCitedEvent({
+        type: "source-url",
+        sourceId: "web-1",
+        url: "https://example.com/a",
+      }).durable;
+      const frames = customFramesFor(2, { ...native, ...v2Envelope(1, "smuggle:type") });
+      assertEquals(frames.length, 1);
+      const data = (frames[0] as { data: Record<string, unknown> }).data;
+      assertEquals(
+        data.type,
+        "source-url",
+        "the rebuilt CUSTOM twin's type field must be the legacy custom name derived from the stored type",
+      );
+    });
+
+    // Regression guard: a DOCUMENT_CITED chunk built with an empty title
+    // must still read back with a renderable (non-empty) title after a
+    // durable round trip, since ChatSourceDocumentUiPart.title is required
+    // at the chat UI type level -- buildDocumentCitedEvent falls back to
+    // sourceId instead of dropping it, so there is nothing for this reader
+    // to restore, and a replayed record renders exactly as the live frame
+    // did.
+    it("replays a DOCUMENT_CITED citation built with an empty title as its sourceId-titled CUSTOM twin", () => {
+      const durable = buildDocumentCitedEvent({
+        type: "source-document",
+        sourceId: "doc-1",
+        mediaType: "text/markdown",
+        title: "",
+      }).durable;
+      assertEquals(
+        durable.title,
+        "doc-1",
+        "the durable record must fall back to a non-empty title",
+      );
+
+      const frames = customFramesFor(2, { ...durable, ...v2Envelope(1, "empty-title-fallback") });
+      assertEquals(frames.length, 1);
+      const data = (frames[0] as { data: Record<string, unknown> }).data;
+      assertEquals(data.title, "doc-1", "the replayed CUSTOM twin must keep the fallback title");
+    });
   });
 });

--- a/src/agent/conversation/legacy-run-read-adapter.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.ts
@@ -87,18 +87,13 @@ function readNativeAsLegacyCustom(
     // before storing, so it must be reinstated here to make the twin exact.
     // `...value` first for the same reason as the input-request case above.
     //
-    // DOCUMENT_CITED's title is required at the chat UI type level
-    // (ChatSourceDocumentUiPart.title is not optional, unlike its siblings'
-    // title/filename/url), so buildDocumentCitedEvent never lets it be
-    // dropped from either shape -- it falls back to sourceId instead of an
-    // empty string -- and there is nothing to restore here. FILE_ATTACHED's
-    // url has the same chat-type requirement but no safe non-empty
-    // fallback (a placeholder url would be an actively misleading, possibly
-    // broken link), so a chunk whose url was empty is, once stored and
-    // replayed, indistinguishable from one that never had a url at all and
-    // reads back the same way: unrenderable, falling back to a raw data
-    // chunk on replay even though the live frame (which keeps the empty
-    // string) rendered it correctly the first time. Known, accepted gap.
+    // An empty title/filename/url never reaches this stored value in the
+    // first place (native-run-events.ts's omitEmptyStrings drops it from
+    // the one payload both the live frame and this durable record share,
+    // I1), so there is nothing to restore here: a replayed record renders
+    // exactly the way the chat decoder's own fallback (source id for a
+    // missing DOCUMENT_CITED title, a raw data chunk for a missing
+    // FILE_ATTACHED url) already renders the live frame.
     return {
       name: definition.legacyCustomName,
       value: { ...value, type: definition.legacyCustomName },

--- a/src/agent/conversation/legacy-run-read-adapter.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.ts
@@ -69,11 +69,15 @@ function readNativeAsLegacyCustom(
     definition.storedType === "INPUT_REQUEST_CREATED" ||
     definition.storedType === "INPUT_REQUEST_UPDATED"
   ) {
+    // `...value` first so a key smuggled inside the stored value (e.g. an
+    // "action" field the native builders never write) cannot win over the
+    // action this reader derives from the stored type -- mirrors the chat
+    // decoder's `{ ...payload, type: "source-document" }` at ag-ui.ts:1039.
     return {
       name: definition.legacyCustomName,
       value: {
-        action: definition.storedType === "INPUT_REQUEST_CREATED" ? "created" : "updated",
         ...value,
+        action: definition.storedType === "INPUT_REQUEST_CREATED" ? "created" : "updated",
       },
     };
   }
@@ -81,9 +85,23 @@ function readNativeAsLegacyCustom(
     // The citation and file twins carried the whole chunk, type field
     // included, as their CUSTOM value. The native builders strip that field
     // before storing, so it must be reinstated here to make the twin exact.
+    // `...value` first for the same reason as the input-request case above.
+    //
+    // DOCUMENT_CITED's title is required at the chat UI type level
+    // (ChatSourceDocumentUiPart.title is not optional, unlike its siblings'
+    // title/filename/url), so buildDocumentCitedEvent never lets it be
+    // dropped from either shape -- it falls back to sourceId instead of an
+    // empty string -- and there is nothing to restore here. FILE_ATTACHED's
+    // url has the same chat-type requirement but no safe non-empty
+    // fallback (a placeholder url would be an actively misleading, possibly
+    // broken link), so a chunk whose url was empty is, once stored and
+    // replayed, indistinguishable from one that never had a url at all and
+    // reads back the same way: unrenderable, falling back to a raw data
+    // chunk on replay even though the live frame (which keeps the empty
+    // string) rendered it correctly the first time. Known, accepted gap.
     return {
       name: definition.legacyCustomName,
-      value: { type: definition.legacyCustomName, ...value },
+      value: { ...value, type: definition.legacyCustomName },
     };
   }
   return { name: definition.legacyCustomName, value };

--- a/src/agent/conversation/legacy-run-read-adapter.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.ts
@@ -71,8 +71,9 @@ function readNativeAsLegacyCustom(
   ) {
     // `...value` first so a key smuggled inside the stored value (e.g. an
     // "action" field the native builders never write) cannot win over the
-    // action this reader derives from the stored type -- mirrors the chat
-    // decoder's `{ ...payload, type: "source-document" }` at ag-ui.ts:1039.
+    // action this reader derives from the stored type -- mirrors this same
+    // reader's `{ ...value, type: definition.legacyCustomName }` in the
+    // citation/file case below.
     return {
       name: definition.legacyCustomName,
       value: {
@@ -88,8 +89,8 @@ function readNativeAsLegacyCustom(
     // `...value` first for the same reason as the input-request case above.
     //
     // An empty title/filename/url never reaches this stored value in the
-    // first place (native-run-events.ts's omitEmptyStrings drops it from
-    // the one payload both the live frame and this durable record share,
+    // first place (native-run-events.ts's omitInvalidOptionalStrings drops
+    // it from the one payload both the live frame and this durable record share,
     // I1), so there is nothing to restore here: a replayed record renders
     // exactly the way the chat decoder's own fallback (source id for a
     // missing DOCUMENT_CITED title, a raw data chunk for a missing

--- a/src/agent/conversation/legacy-run-read-adapter.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.ts
@@ -7,7 +7,72 @@ import {
   type StreamProtocolEvent,
   type StreamReducerState,
 } from "#veryfront/agent/streaming/lifecycle/index.ts";
+import { NATIVE_RUN_EVENTS, type NativeRunEventDefinition } from "../ag-ui/native-run-events.ts";
 import type { StreamProtocolVersion } from "./durable-contracts.ts";
+
+const NATIVE_STORED_TYPE_TO_LEGACY: ReadonlyMap<string, NativeRunEventDefinition> = new Map(
+  NATIVE_RUN_EVENTS.map((definition) => [definition.storedType as string, definition]),
+);
+
+const NATIVE_CITATION_AND_FILE_STORED_TYPES: ReadonlySet<string> = new Set([
+  "URL_CITED",
+  "DOCUMENT_CITED",
+  "FILE_ATTACHED",
+]);
+
+// The version 2 writer stamps these onto every durable record's own top
+// level, native records included. A CUSTOM record never leaks them into its
+// `value` because that value is nested; a native record's payload sits at
+// the same level as these, so they must be stripped explicitly here or they
+// would leak into the rebuilt CUSTOM value.
+const DURABLE_ENVELOPE_KEYS = [
+  "type",
+  "stream_protocol_version",
+  "attempt_id",
+  "attempt_index",
+  "logical_sequence",
+  "idempotency_key",
+] as const;
+
+/**
+ * Reads a natively stored extension record back as the custom lifecycle event
+ * its CUSTOM twin produced, so consumers of this adapter see one shape.
+ * legacy: removed in Phase F - consumers then read the native types directly.
+ */
+function readNativeAsLegacyCustom(
+  event: Record<string, unknown>,
+): { name: string; value: Record<string, unknown> } | null {
+  const definition = typeof event.type === "string"
+    ? NATIVE_STORED_TYPE_TO_LEGACY.get(event.type)
+    : undefined;
+  if (!definition) return null;
+  const value = { ...event };
+  for (const key of DURABLE_ENVELOPE_KEYS) {
+    delete value[key];
+  }
+  if (
+    definition.storedType === "INPUT_REQUEST_CREATED" ||
+    definition.storedType === "INPUT_REQUEST_UPDATED"
+  ) {
+    return {
+      name: definition.legacyCustomName,
+      value: {
+        action: definition.storedType === "INPUT_REQUEST_CREATED" ? "created" : "updated",
+        ...value,
+      },
+    };
+  }
+  if (NATIVE_CITATION_AND_FILE_STORED_TYPES.has(definition.storedType)) {
+    // The citation and file twins carried the whole chunk, type field
+    // included, as their CUSTOM value. The native builders strip that field
+    // before storing, so it must be reinstated here to make the twin exact.
+    return {
+      name: definition.legacyCustomName,
+      value: { type: definition.legacyCustomName, ...value },
+    };
+  }
+  return { name: definition.legacyCustomName, value };
+}
 
 /** Projection-only repairs applied while reading historical run events. */
 export type ConversationRunLifecycleRepair =
@@ -211,9 +276,15 @@ function readVersion1(
           data: event.value,
         });
         break;
-      default:
+      default: {
+        const native = readNativeAsLegacyCustom(event);
+        if (native) {
+          reduce({ type: "custom", name: native.name, data: native.value });
+          break;
+        }
         rejectUnknown();
         break;
+      }
     }
   }
 
@@ -511,8 +582,14 @@ function readVersion2(
           data: event.value,
         });
         break;
-      default:
+      default: {
+        const native = readNativeAsLegacyCustom(event);
+        if (native) {
+          push({ type: "custom", name: native.name, data: native.value });
+          break;
+        }
         return invalid("UNSUPPORTED_DURABLE_EVENT");
+      }
     }
   }
 

--- a/src/agent/conversation/legacy-run-read-adapter.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.ts
@@ -14,14 +14,27 @@ const NATIVE_STORED_TYPE_TO_LEGACY: ReadonlyMap<string, NativeRunEventDefinition
   NATIVE_RUN_EVENTS.map((definition) => [definition.storedType as string, definition]),
 );
 
+// Which native events carry their CUSTOM twin's whole original chunk (type
+// field included) as the value, rather than a synthesized shape. That split
+// is a domain fact about each builder (buildUrlCitedEvent,
+// buildDocumentCitedEvent, and buildFileAttachedEvent all destructure a
+// source chunk), not something recorded on NativeRunEventDefinition itself,
+// so it cannot be derived from NATIVE_RUN_EVENTS without adding a field to
+// that module. Keep this trio in sync with those three builders if a new
+// citation- or file-shaped native event is ever added.
 const NATIVE_CITATION_AND_FILE_STORED_TYPES: ReadonlySet<string> = new Set([
   "URL_CITED",
   "DOCUMENT_CITED",
   "FILE_ATTACHED",
 ]);
 
-// The version 2 writer stamps these onto every durable record's own top
-// level, native records included. A CUSTOM record never leaks them into its
+// Stamped onto every durable event's own top level -- native records
+// included -- by both writers: the version 2 writer's `publish()`
+// (lifecycle-run-event-adapter.ts) adds the five protocol envelope fields,
+// and the version 1 `ConversationRunEventEncoder.stampElapsed()`
+// (run-events.ts), which also builds the native durable records for
+// TOOL_CALL_STATUS_CHANGED/URL_CITED/DOCUMENT_CITED/FILE_ATTACHED, adds
+// `elapsedMs`/`emittedAt`. A CUSTOM record never leaks any of these into its
 // `value` because that value is nested; a native record's payload sits at
 // the same level as these, so they must be stripped explicitly here or they
 // would leak into the rebuilt CUSTOM value.
@@ -32,6 +45,8 @@ const DURABLE_ENVELOPE_KEYS = [
   "attempt_index",
   "logical_sequence",
   "idempotency_key",
+  "elapsedMs",
+  "emittedAt",
 ] as const;
 
 /**

--- a/src/agent/conversation/lifecycle-run-event-adapter.test.ts
+++ b/src/agent/conversation/lifecycle-run-event-adapter.test.ts
@@ -56,6 +56,7 @@ describe("lifecycle run event adapter", () => {
           event: {
             type: "tool_input_status",
             toolCallId: "tool-1",
+            toolCallName: "create_file",
             status: "pending_input",
           },
         },
@@ -64,6 +65,7 @@ describe("lifecycle run event adapter", () => {
           event: {
             type: "tool_input_status",
             toolCallId: "tool-1",
+            toolCallName: "create_file",
             status: "pending_input",
           },
         },
@@ -79,13 +81,15 @@ describe("lifecycle run event adapter", () => {
       "TEXT_MESSAGE_START",
       "TEXT_MESSAGE_CONTENT",
       "TEXT_MESSAGE_END",
-      "CUSTOM",
+      "TOOL_CALL_STATUS_CHANGED",
     ]);
     assertEquals(emitted[1]?.delta, "hello world");
     assertEquals(emitted[3], {
-      type: "CUSTOM",
-      name: "tool-call-status",
-      value: { toolCallId: "tool-1", status: "pending_input" },
+      type: "TOOL_CALL_STATUS_CHANGED",
+      toolCallId: "tool-1",
+      status: "pending_input",
+      toolCallName: "create_file",
+      parentMessageId: "message-1",
       stream_protocol_version: 2,
       attempt_id: "attempt-1",
       attempt_index: 0,
@@ -126,7 +130,12 @@ describe("lifecycle run event adapter", () => {
     }
     adapter.dispose();
     assertEquals(
-      emitted.map((event) => event.value as { toolCallId: string; status: string }),
+      emitted.map((event) =>
+        ({
+          toolCallId: event.toolCallId,
+          status: event.status,
+        }) as { toolCallId: string; status: string }
+      ),
       [
         { toolCallId: "tool-1", status: "pending_input" },
         { toolCallId: "tool-2", status: "pending_input" },

--- a/src/agent/conversation/lifecycle-run-event-adapter.test.ts
+++ b/src/agent/conversation/lifecycle-run-event-adapter.test.ts
@@ -110,11 +110,11 @@ describe("lifecycle run event adapter", () => {
     const { emitted, adapter } = createCollector();
     for (
       const tick of [
-        { toolCallId: "tool-1", status: "pending_input" },
-        { toolCallId: "tool-2", status: "pending_input" },
-        { toolCallId: "tool-1", status: "pending_input" },
-        { toolCallId: "tool-1", status: "streaming_input" },
-        { toolCallId: "tool-2", status: "streaming_input" },
+        { toolCallId: "tool-1", toolCallName: null, status: "pending_input" },
+        { toolCallId: "tool-2", toolCallName: null, status: "pending_input" },
+        { toolCallId: "tool-1", toolCallName: null, status: "pending_input" },
+        { toolCallId: "tool-1", toolCallName: null, status: "streaming_input" },
+        { toolCallId: "tool-2", toolCallName: null, status: "streaming_input" },
       ] as const
     ) {
       adapter.handleFrame({

--- a/src/agent/conversation/lifecycle-run-event-adapter.ts
+++ b/src/agent/conversation/lifecycle-run-event-adapter.ts
@@ -1,4 +1,8 @@
 import type { StreamLifecycleFrame } from "#veryfront/agent/streaming/lifecycle/index.ts";
+import {
+  buildNativeRunEventFrame,
+  buildToolCallStatusChangedEvent,
+} from "../ag-ui/native-run-events.ts";
 import { normalizeConversationRunEvents } from "./run-event-normalization.ts";
 import {
   type ConversationRunEvent,
@@ -322,13 +326,21 @@ export function createLifecycleRunEventAdapter(input: {
         streamedToolInputs.delete(event.toolCallId);
         return;
       }
-      case "custom":
-        emit({
-          type: conversationRunEventTypes.custom,
+      case "custom": {
+        const native = buildNativeRunEventFrame({
           name: event.name,
           value: event.data,
+          parentMessageId: input.messageId,
         });
+        emit(
+          native ? native.durable : {
+            type: conversationRunEventTypes.custom,
+            name: event.name,
+            value: event.data,
+          },
+        );
         return;
+      }
       case "message_start":
       case "step_start":
         return;
@@ -348,11 +360,14 @@ export function createLifecycleRunEventAdapter(input: {
         const { toolCallId, status } = frame.event;
         if (lastToolStatus.get(toolCallId) === status) return;
         lastToolStatus.set(toolCallId, status);
-        emit({
-          type: conversationRunEventTypes.custom,
-          name: "tool-call-status",
-          value: { toolCallId, status },
-        });
+        emit(
+          buildToolCallStatusChangedEvent({
+            toolCallId,
+            status,
+            toolCallName: frame.event.toolCallName,
+            parentMessageId: input.messageId,
+          }).durable,
+        );
         return;
       }
       handleSemantic(frame.event);

--- a/src/agent/conversation/run-event-normalization.test.ts
+++ b/src/agent/conversation/run-event-normalization.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   getConversationRunEventJsonByteLength,
@@ -246,6 +246,34 @@ describe("agent/conversation-run-event-normalization", () => {
       );
     }
   });
+
+  for (
+    const type of [
+      "TOOL_CALL_STATUS_CHANGED",
+      "INPUT_REQUEST_CREATED",
+      "INPUT_REQUEST_UPDATED",
+      "CHILD_RUN_STATUS_CHANGED",
+    ]
+  ) {
+    it(`replaces oversized ${type} records with a bounded omission marker`, () => {
+      const [event] = normalizeConversationRunEvent({
+        type,
+        toolCallId: "tool-1",
+        status: "running",
+        arguments: "x".repeat(MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES),
+      });
+      assert(event);
+      assertEquals(event.type, "CUSTOM");
+      assertEquals(event.name, "conversation-run-event-omitted");
+      assertEquals(event.originalType, type);
+      assertEquals(event.originalToolCallId, "tool-1");
+      assertEquals(event.truncated, true);
+      assertEquals(
+        getConversationRunEventJsonByteLength(event) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
+        true,
+      );
+    });
+  }
 
   it("normalizes whole event lists", () => {
     const events = [

--- a/src/agent/conversation/run-event-normalization.ts
+++ b/src/agent/conversation/run-event-normalization.ts
@@ -5,6 +5,7 @@ import {
   isPrivateConversationRunEvent,
 } from "./private-run-event.ts";
 import { AGENT_RUN_PROVIDER_REPLAY_CHECKPOINT_EVENT_TYPE } from "#veryfront/agent/runtime/provider-replay.ts";
+import { isNativeRunEventStoredType } from "#veryfront/agent/ag-ui/native-run-events.ts";
 
 export { MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES } from "./run-event-limits.ts";
 const OMITTED_CONVERSATION_RUN_EVENT_TYPE = "CUSTOM";
@@ -73,8 +74,29 @@ function summarizeOversizedEvent(
     case "TOOL_CALL_RESULT":
       return [summarizeToolResultEvent(event)];
 
+    // The `url` field is where these three carry an oversized value (typically
+    // an inline `data:` URL); truncating it keeps every API-catalog-required
+    // field (`mediaType`, `sourceId`, ...) intact, unlike the generic summary.
+    case "URL_CITED":
+    case "DOCUMENT_CITED":
+    case "FILE_ATTACHED": {
+      if (typeof event.url === "string") {
+        const truncated = truncateEventStringFieldToLimit(event, "url", " [truncated]");
+        if (truncated) return [truncated];
+      }
+      return [buildOmittedEvent(event)];
+    }
+
     default:
-      return [summarizeGenericEvent(event)];
+      // A native record type (TOOL_CALL_STATUS_CHANGED, INPUT_REQUEST_*,
+      // CHILD_RUN_STATUS_CHANGED) carries API-catalog-required fields beyond
+      // `type`. summarizeGenericEvent's `{ type, truncated, note, summary }`
+      // shape drops those and fails validation, unlike the permissive legacy
+      // `CUSTOM` wrapper it replaced -- so a native type falls back to the
+      // always-valid omission event instead.
+      return isNativeRunEventStoredType(event.type)
+        ? [buildOmittedEvent(event)]
+        : [summarizeGenericEvent(event)];
   }
 }
 

--- a/src/agent/conversation/run-event-normalization.ts
+++ b/src/agent/conversation/run-event-normalization.ts
@@ -74,14 +74,27 @@ function summarizeOversizedEvent(
     case "TOOL_CALL_RESULT":
       return [summarizeToolResultEvent(event)];
 
-    // The `url` field is where these three carry an oversized value (typically
+    // The `url` field is where these two carry an oversized value (typically
     // an inline `data:` URL); truncating it keeps every API-catalog-required
     // field (`mediaType`, `sourceId`, ...) intact, unlike the generic summary.
+    // DOCUMENT_CITED has no `url` field (ChatSourceDocumentUiPart carries
+    // none), so it always falls straight to the omission event below --
+    // dropped from this case rather than left to fail the `typeof` check,
+    // since it behaves identically either way.
     case "URL_CITED":
-    case "DOCUMENT_CITED":
     case "FILE_ATTACHED": {
       if (typeof event.url === "string") {
-        const truncated = truncateEventStringFieldToLimit(event, "url", " [truncated]");
+        // buildUrlCitedEvent falls back to `sourceId = url` when the source
+        // chunk has no id of its own, so a citation's sourceId can mirror an
+        // oversized url exactly; truncate both together in that case (see
+        // truncateEventStringFieldToLimit's mirrorField).
+        const sourceIdMirrorsUrl = event.type === "URL_CITED" && event.sourceId === event.url;
+        const truncated = truncateEventStringFieldToLimit(
+          event,
+          "url",
+          " [truncated]",
+          sourceIdMirrorsUrl ? "sourceId" : undefined,
+        );
         if (truncated) return [truncated];
       }
       return [buildOmittedEvent(event)];
@@ -179,21 +192,32 @@ function summarizeToolResultEvent(event: ConversationRunEventRecord): Conversati
  * Measures the JSON-serialized event (not the raw string), so it stays correct
  * for escape-heavy content that expands under JSON.stringify — the same unit the
  * API enforces. Returns null when the envelope alone already exceeds the limit.
+ *
+ * `mirrorField`, when given, is set to the same truncated string as `field`
+ * in every candidate the search tries -- for a URL_CITED record whose
+ * `sourceId` mirrors an oversized `url` (buildUrlCitedEvent's fallback when
+ * the chunk had no source id of its own), truncating `url` alone would leave
+ * `sourceId` unchanged and the record still over the limit, so both fields
+ * must shrink together rather than being sized independently.
  */
 function truncateEventStringFieldToLimit(
   event: ConversationRunEventRecord,
   field: string,
   suffix: string,
+  mirrorField?: string,
 ): ConversationRunEventRecord | null {
   const value = event[field];
   if (typeof value !== "string") {
     return null;
   }
 
-  const buildCandidate = (prefixLength: number): ConversationRunEventRecord =>
-    prefixLength >= value.length
-      ? event
-      : { ...event, [field]: `${value.slice(0, prefixLength)}${suffix}` };
+  const buildCandidate = (prefixLength: number): ConversationRunEventRecord => {
+    if (prefixLength >= value.length) return event;
+    const truncatedValue = `${value.slice(0, prefixLength)}${suffix}`;
+    return mirrorField
+      ? { ...event, [field]: truncatedValue, [mirrorField]: truncatedValue }
+      : { ...event, [field]: truncatedValue };
+  };
 
   if (
     getConversationRunEventJsonByteLength(buildCandidate(value.length)) <=

--- a/src/agent/conversation/run-event-normalization.ts
+++ b/src/agent/conversation/run-event-normalization.ts
@@ -5,7 +5,10 @@ import {
   isPrivateConversationRunEvent,
 } from "./private-run-event.ts";
 import { AGENT_RUN_PROVIDER_REPLAY_CHECKPOINT_EVENT_TYPE } from "#veryfront/agent/runtime/provider-replay.ts";
-import { isNativeRunEventStoredType } from "#veryfront/agent/ag-ui/native-run-events.ts";
+import {
+  buildNativeRunEventFrame,
+  isNativeRunEventStoredType,
+} from "#veryfront/agent/ag-ui/native-run-events.ts";
 
 export { MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES } from "./run-event-limits.ts";
 const OMITTED_CONVERSATION_RUN_EVENT_TYPE = "CUSTOM";
@@ -34,6 +37,21 @@ export function getConversationRunEventJsonByteLength(value: unknown): number {
   }
 }
 
+function normalizeChildRunLifecycleEvent(
+  event: ConversationRunEventRecord,
+): ConversationRunEventRecord {
+  // Public child-run builders and publisher callbacks retain their Custom
+  // contract. Convert at the shared direct-append and mirror boundary.
+  if (event.type === "CUSTOM" && event.name === "veryfront.invoke_agent.lifecycle") {
+    const native = buildNativeRunEventFrame({ name: event.name, value: event.value });
+    if (native) {
+      const { name: _name, value: _value, ...metadata } = event;
+      event = { ...metadata, ...native.durable };
+    }
+  }
+  return event;
+}
+
 /** Event emitted for normalize conversation run. */
 export function normalizeConversationRunEvent(
   event: ConversationRunEventRecord,
@@ -52,6 +70,7 @@ export function normalizeConversationRunEvent(
     }
     return [event];
   }
+  event = normalizeChildRunLifecycleEvent(event);
   if (getConversationRunEventJsonByteLength(event) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES) {
     return [event];
   }

--- a/src/agent/conversation/run-events.test.ts
+++ b/src/agent/conversation/run-events.test.ts
@@ -8,7 +8,10 @@ import {
   normalizeEncodedConversationRunEvents,
   serializeConversationToolResultContent,
 } from "./run-events.ts";
-import { MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES } from "./run-event-normalization.ts";
+import {
+  getConversationRunEventJsonByteLength,
+  MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
+} from "./run-event-normalization.ts";
 
 describe("agent/conversation-run-events", () => {
   it("stores a textual rendering for tool output JSON cannot encode", () => {
@@ -214,6 +217,39 @@ describe("agent/conversation-run-events", () => {
           toolCallId: "tc-1",
           status: "pending_input",
           toolCallName: "create_file",
+        },
+      ],
+    );
+  });
+
+  it("carries tool result, error, and argument fields through a native tool-call-status record", () => {
+    // The legacy `Custom` wrapper passed the whole value through unchanged, and
+    // src/eval/agent-service.ts's applyToolCallStatusEvent still reads these
+    // fields off the native record when a standard tool result is absent.
+    const encoder = new ConversationRunEventEncoder();
+    assertEquals(
+      encoder.encode({
+        type: "data-tool-call-status",
+        data: {
+          toolCallId: "tc-1",
+          toolCallName: "write",
+          status: "completed",
+          arguments: { path: "file.txt" },
+          result: { ok: false },
+          error: { message: "write denied" },
+          exitCode: 1,
+        },
+      }),
+      [
+        {
+          type: conversationRunEventTypes.toolCallStatusChanged,
+          toolCallId: "tc-1",
+          status: "completed",
+          toolCallName: "write",
+          arguments: { path: "file.txt" },
+          result: { ok: false },
+          error: { message: "write denied" },
+          exitCode: 1,
         },
       ],
     );
@@ -591,6 +627,30 @@ describe("agent/conversation-run-events", () => {
       contentParts.every((event) => event.elapsedMs === 250),
       true,
       "every split part keeps the elapsed of the event it came from",
+    );
+  });
+
+  it("keeps an oversized native file record valid by truncating its url, not its required fields", () => {
+    // An inline `data:` url can push a FILE_ATTACHED record over the byte
+    // budget. The generic summary this used to fall through to drops
+    // `mediaType`, which the API catalog requires, and fails append.
+    const events = [{
+      type: "file",
+      url: "data:image/png;base64," + "A".repeat(250 * 1024),
+      mediaType: "image/png",
+    }];
+    const [normalized] = normalizeEncodedConversationRunEvents(events as never);
+
+    assertEquals(normalized.type, conversationRunEventTypes.fileAttached);
+    assertEquals(normalized.mediaType, "image/png");
+    assertEquals(
+      typeof normalized.url === "string" && (normalized.url as string).length < 250 * 1024,
+      true,
+      "the oversized url must be truncated",
+    );
+    assertEquals(
+      getConversationRunEventJsonByteLength(normalized) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
+      true,
     );
   });
 });

--- a/src/agent/conversation/run-events.test.ts
+++ b/src/agent/conversation/run-events.test.ts
@@ -201,24 +201,43 @@ describe("agent/conversation-run-events", () => {
     );
   });
 
-  it("encodes data-* chunks as custom events", () => {
+  it("encodes native data-* chunks as native durable records", () => {
     const encoder = new ConversationRunEventEncoder();
     assertEquals(
       encoder.encode({
         type: "data-tool-call-status",
-        data: { toolCallId: "tc-1", status: "pending_input" },
+        data: { toolCallId: "tc-1", toolCallName: "create_file", status: "pending_input" },
       }),
       [
         {
-          type: conversationRunEventTypes.custom,
-          name: "tool-call-status",
-          value: { toolCallId: "tc-1", status: "pending_input" },
+          type: conversationRunEventTypes.toolCallStatusChanged,
+          toolCallId: "tc-1",
+          status: "pending_input",
+          toolCallName: "create_file",
         },
       ],
     );
   });
 
-  it("encodes source documents as durable custom events", () => {
+  it("keeps state chunks and unknown data names custom", () => {
+    const encoder = new ConversationRunEventEncoder();
+    assertEquals(
+      encoder.encode({ type: "data-state-delta", data: { ops: [] } }),
+      [
+        {
+          type: conversationRunEventTypes.custom,
+          name: "state-delta",
+          value: { ops: [] },
+        },
+      ],
+    );
+    assertEquals(
+      encoder.encode({ type: "data-foo", data: { a: 1 } }),
+      [{ type: conversationRunEventTypes.custom, name: "foo", value: { a: 1 } }],
+    );
+  });
+
+  it("encodes source documents as native document citations", () => {
     const encoder = new ConversationRunEventEncoder();
     const path = "knowledge/knowledge-ingest-20260723131451088-source.md";
 
@@ -231,49 +250,98 @@ describe("agent/conversation-run-events", () => {
         filename: path,
       }),
       [{
-        type: conversationRunEventTypes.custom,
-        name: "source-document",
-        value: {
-          type: "source-document",
-          sourceId: path,
-          mediaType: "text/markdown",
-          title: path,
-          filename: path,
-        },
+        type: conversationRunEventTypes.documentCited,
+        sourceId: path,
+        mediaType: "text/markdown",
+        title: path,
+        filename: path,
       }],
     );
   });
 
-  it("encodes source URLs as durable custom events", () => {
+  it("encodes source URLs as native URL citations", () => {
     const encoder = new ConversationRunEventEncoder();
-    const sourceUrl = {
-      type: "source-url" as const,
-      sourceId: "web-1",
-      url: "https://example.com/reference",
-      title: "Reference",
-    };
 
-    assertEquals(encoder.encode(sourceUrl), [{
-      type: conversationRunEventTypes.custom,
-      name: "source-url",
-      value: sourceUrl,
-    }]);
+    assertEquals(
+      encoder.encode({
+        type: "source-url",
+        sourceId: "web-1",
+        url: "https://example.com/reference",
+        title: "Reference",
+      }),
+      [{
+        type: conversationRunEventTypes.urlCited,
+        sourceId: "web-1",
+        url: "https://example.com/reference",
+        title: "Reference",
+      }],
+    );
   });
 
-  it("encodes files as durable custom events", () => {
+  it("encodes files as native file attachments", () => {
     const encoder = new ConversationRunEventEncoder();
-    const file = {
-      type: "file" as const,
-      url: "https://cdn.example.com/report.pdf",
-      mediaType: "application/pdf",
-      filename: "report.pdf",
-    };
 
-    assertEquals(encoder.encode(file), [{
-      type: conversationRunEventTypes.custom,
-      name: "file",
-      value: file,
-    }]);
+    assertEquals(
+      encoder.encode({
+        type: "file",
+        url: "https://cdn.example.com/report.pdf",
+        mediaType: "application/pdf",
+        filename: "report.pdf",
+      }),
+      [{
+        type: conversationRunEventTypes.fileAttached,
+        url: "https://cdn.example.com/report.pdf",
+        mediaType: "application/pdf",
+        filename: "report.pdf",
+      }],
+    );
+  });
+
+  it("names the parent message on tool records inside an open message", () => {
+    const encoder = new ConversationRunEventEncoder();
+    assertEquals(encoder.encode({ type: "start", messageId: "assistant-1" }), []);
+    assertEquals(
+      encoder.encode({
+        type: "data-tool-call-status",
+        data: { toolCallId: "tc-1", toolCallName: "create_file", status: "streaming_input" },
+      }),
+      [
+        {
+          type: conversationRunEventTypes.toolCallStatusChanged,
+          toolCallId: "tc-1",
+          status: "streaming_input",
+          toolCallName: "create_file",
+          parentMessageId: "assistant-1",
+        },
+      ],
+    );
+    // The API derives tool spans from the rows it stores, and these are those
+    // rows, so the start record names its turn too.
+    assertEquals(
+      encoder.encode({ type: "tool-input-start", toolCallId: "tc-1", toolName: "create_file" }),
+      [
+        {
+          type: conversationRunEventTypes.toolCallStart,
+          toolCallId: "tc-1",
+          toolCallName: "create_file",
+          parentMessageId: "assistant-1",
+        },
+      ],
+    );
+  });
+
+  it("leaves a tool call start outside any message unchanged", () => {
+    const encoder = new ConversationRunEventEncoder();
+    assertEquals(
+      encoder.encode({ type: "tool-input-start", toolCallId: "tc-1", toolName: "create_file" }),
+      [
+        {
+          type: conversationRunEventTypes.toolCallStart,
+          toolCallId: "tc-1",
+          toolCallName: "create_file",
+        },
+      ],
+    );
   });
 
   it("gives an unresolved provider-executed tool call a durable terminal result", () => {

--- a/src/agent/conversation/run-events.test.ts
+++ b/src/agent/conversation/run-events.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   ConversationRunEventEncoder,
@@ -640,6 +640,7 @@ describe("agent/conversation-run-events", () => {
       mediaType: "image/png",
     }];
     const [normalized] = normalizeEncodedConversationRunEvents(events as never);
+    assertExists(normalized);
 
     assertEquals(normalized.type, conversationRunEventTypes.fileAttached);
     assertEquals(normalized.mediaType, "image/png");
@@ -648,6 +649,56 @@ describe("agent/conversation-run-events", () => {
       true,
       "the oversized url must be truncated",
     );
+  });
+
+  it("re-derives sourceId from the truncated url when a URL_CITED citation had none of its own", () => {
+    // M1: buildUrlCitedEvent falls back to sourceId = url when the chunk has
+    // no source id. If that url is the oversized value, truncating url alone
+    // leaves sourceId mirroring the untouched oversized string, so the
+    // record stays over the limit and degrades to the CUSTOM omission event
+    // -- lossier than it needs to be.
+    const oversizedUrl = "data:image/png;base64," + "A".repeat(250 * 1024);
+    const events = [{ type: "source-url", url: oversizedUrl }];
+    const [normalized] = normalizeEncodedConversationRunEvents(events as never);
+    assertExists(normalized);
+
+    assertEquals(
+      normalized.type,
+      conversationRunEventTypes.urlCited,
+      "the citation must survive as URL_CITED, not degrade to the omission event",
+    );
+    assertEquals(
+      typeof normalized.url === "string" && (normalized.url as string).length < 250 * 1024,
+      true,
+      "the oversized url must be truncated",
+    );
+    assertEquals(
+      normalized.sourceId,
+      normalized.url,
+      "sourceId must be re-derived from the truncated url, not left mirroring the untruncated one",
+    );
+    assertEquals(
+      getConversationRunEventJsonByteLength(normalized) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
+      true,
+    );
+  });
+
+  it("does not attempt to truncate an oversized DOCUMENT_CITED citation's absent url field", () => {
+    // M2: ChatSourceDocumentUiPart has no url field, so DOCUMENT_CITED always
+    // falls to the always-valid omission event for an oversized record --
+    // dropped from the url-truncation case rather than left to fail its
+    // `typeof event.url === "string"` check, since the two behave
+    // identically.
+    const events = [{
+      type: "source-document",
+      sourceId: "doc-1",
+      mediaType: "text/markdown",
+      title: "A".repeat(250 * 1024),
+    }];
+    const [normalized] = normalizeEncodedConversationRunEvents(events as never);
+    assertExists(normalized);
+
+    assertEquals(normalized.type, conversationRunEventTypes.custom);
     assertEquals(
       getConversationRunEventJsonByteLength(normalized) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
       true,

--- a/src/agent/conversation/run-events.test.ts
+++ b/src/agent/conversation/run-events.test.ts
@@ -219,6 +219,28 @@ describe("agent/conversation-run-events", () => {
     );
   });
 
+  it("encodes native child-run lifecycle chunks as native durable records", () => {
+    const encoder = new ConversationRunEventEncoder();
+    assertEquals(
+      encoder.encode({
+        type: "data-veryfront.invoke_agent.lifecycle",
+        data: {
+          toolCallId: "toolu_child_1",
+          childRunId: "run_child_1",
+          status: "running",
+        },
+      }),
+      [
+        {
+          type: conversationRunEventTypes.childRunStatusChanged,
+          toolCallId: "toolu_child_1",
+          childRunId: "run_child_1",
+          status: "running",
+        },
+      ],
+    );
+  });
+
   it("keeps state chunks and unknown data names custom", () => {
     const encoder = new ConversationRunEventEncoder();
     assertEquals(

--- a/src/agent/conversation/run-events.ts
+++ b/src/agent/conversation/run-events.ts
@@ -1,6 +1,7 @@
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
 import { type ChatStreamEvent } from "#veryfront/chat/protocol.ts";
+import { buildNativeRunEventFrame, nativeRunEventTypes } from "../ag-ui/native-run-events.ts";
 import type { AgentRunEventTimingOptions } from "../../runtime/model-call-context.ts";
 import { normalizeConversationRunEvents } from "./run-event-normalization.ts";
 
@@ -19,6 +20,7 @@ export const conversationRunEventTypes = {
   toolCallArgs: "TOOL_CALL_ARGS",
   toolCallEnd: "TOOL_CALL_END",
   toolCallResult: "TOOL_CALL_RESULT",
+  ...nativeRunEventTypes,
 } as const;
 
 export const getConversationRunEventSchema = defineSchema((v) =>
@@ -93,10 +95,16 @@ function providerExecutionMarker(
 
 function encodeCustomDataEvent(
   chunk: Extract<ChatStreamEvent, { type: `data-${string}` }>,
+  parentMessageId: string | null,
 ): ConversationRunEvent[] {
   const name = chunk.type.slice("data-".length);
   if (name.length === 0) {
     return [];
+  }
+
+  const native = buildNativeRunEventFrame({ name, value: chunk.data, parentMessageId });
+  if (native) {
+    return [native.durable];
   }
 
   return [{
@@ -291,6 +299,7 @@ export class ConversationRunEventEncoder {
           type: conversationRunEventTypes.toolCallStart,
           toolCallId: chunk.toolCallId,
           toolCallName: chunk.toolName,
+          ...(this.activeMessageId ? { parentMessageId: this.activeMessageId } : {}),
           ...providerExecutionMarker(chunk),
         }];
 
@@ -400,12 +409,16 @@ export class ConversationRunEventEncoder {
 
       case "source-document":
       case "source-url":
-      case "file":
-        return [{
-          type: conversationRunEventTypes.custom,
-          name: chunk.type,
-          value: chunk,
-        }];
+      case "file": {
+        const native = buildNativeRunEventFrame({ name: chunk.type, value: chunk });
+        return [
+          native ? native.durable : {
+            type: conversationRunEventTypes.custom,
+            name: chunk.type,
+            value: chunk,
+          },
+        ];
+      }
 
       case "start-step":
         return [{
@@ -427,7 +440,9 @@ export class ConversationRunEventEncoder {
         return [];
 
       default:
-        return chunk.type.startsWith("data-") ? encodeCustomDataEvent(chunk) : [];
+        return chunk.type.startsWith("data-")
+          ? encodeCustomDataEvent(chunk, this.activeMessageId)
+          : [];
     }
   }
 }

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -977,8 +977,8 @@ describe("agent/hosted-durable-child-fork-execution", () => {
             },
             publishParentRunEvents: (events: InvokeAgentChildRunProgressEvent[]) => {
               for (const event of events) {
-                if (event.type === "CHILD_RUN_STATUS_CHANGED") {
-                  lifecycleStatuses.push(event.status);
+                if (event.type === "CUSTOM") {
+                  lifecycleStatuses.push(event.value.status);
                 }
               }
             },

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -977,8 +977,8 @@ describe("agent/hosted-durable-child-fork-execution", () => {
             },
             publishParentRunEvents: (events: InvokeAgentChildRunProgressEvent[]) => {
               for (const event of events) {
-                if (event.type === "CUSTOM") {
-                  lifecycleStatuses.push(event.value.status);
+                if (event.type === "CHILD_RUN_STATUS_CHANGED") {
+                  lifecycleStatuses.push(event.status);
                 }
               }
             },

--- a/src/agent/input/request-protocol.test.ts
+++ b/src/agent/input/request-protocol.test.ts
@@ -8,6 +8,11 @@ import {
   getCreateInputRequestResponseSchema,
   getInputRequest,
 } from "../index.ts";
+import {
+  createAgUiEncoderState,
+  mapRuntimeStreamEventToAgUiEvents,
+} from "#veryfront/agent/ag-ui/encoder.ts";
+import { ConversationRunEventEncoder } from "#veryfront/agent/conversation/run-events.ts";
 
 const API_URL = "https://api.example.com";
 const AUTH_TOKEN = "token-123";
@@ -315,6 +320,44 @@ describe("agent/input-request-protocol", () => {
       name: "veryfront.input_request.lifecycle",
       value: { action: "created", inputRequest },
     });
+  });
+
+  it("reaches both encoders as a native input request event", () => {
+    const inputRequest = getCreateInputRequestResponseSchema().parse(createInputRequestRecord());
+    const created = buildInputRequestLifecycleDataEvent({ action: "created", inputRequest });
+    const updated = buildInputRequestLifecycleDataEvent({ action: "updated", inputRequest });
+
+    // The bridge serializes a named data event as `data-<name>` carrying its
+    // value, so pin the name first and then drive that chunk through both
+    // encoders. This is the whole path from the tool to the wire.
+    assertEquals(created.name, "veryfront.input_request.lifecycle");
+    assertEquals(updated.name, "veryfront.input_request.lifecycle");
+    const createdChunk = {
+      type: "data-veryfront.input_request.lifecycle" as const,
+      data: created.value,
+    };
+    const updatedChunk = {
+      type: "data-veryfront.input_request.lifecycle" as const,
+      data: updated.value,
+    };
+
+    const state = createAgUiEncoderState({ nowMs: null, epochMs: null });
+    assertEquals(
+      mapRuntimeStreamEventToAgUiEvents(state, createdChunk),
+      [{ event: "InputRequestCreated", payload: { inputRequest } }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiEvents(state, updatedChunk),
+      [{ event: "InputRequestUpdated", payload: { inputRequest } }],
+    );
+
+    const encoder = new ConversationRunEventEncoder();
+    assertEquals(encoder.encode(createdChunk), [
+      { type: "INPUT_REQUEST_CREATED", inputRequest },
+    ]);
+    assertEquals(encoder.encode(updatedChunk), [
+      { type: "INPUT_REQUEST_UPDATED", inputRequest },
+    ]);
   });
 
   it("surfaces API failures with response text", async () => {

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -2798,11 +2798,11 @@ describe("active mode heartbeat regression", () => {
       [
         {
           type: "data-tool-call-status",
-          data: { toolCallId: "t1", status: "pending_input" },
+          data: { toolCallId: "t1", toolCallName: "create_file", status: "pending_input" },
         },
         {
           type: "data-tool-call-status",
-          data: { toolCallId: "t1", status: "pending_input" },
+          data: { toolCallId: "t1", toolCallName: "create_file", status: "pending_input" },
         },
       ],
     );

--- a/src/agent/streaming/executor-data-producers.test.ts
+++ b/src/agent/streaming/executor-data-producers.test.ts
@@ -139,7 +139,12 @@ describe("executor data compatibility with runtime producers", () => {
             class: "telemetry",
             sequence: semantic.length,
             elapsedMs: semantic.length,
-            event: { type: "tool_input_status", toolCallId: "local-1", status: "pending_input" },
+            event: {
+              type: "tool_input_status",
+              toolCallId: "local-1",
+              toolCallName: null,
+              status: "pending_input",
+            },
           })
         ) emitter.emit(output);
         emitter.emitFinish();

--- a/src/agent/streaming/lifecycle/live-adapter.test.ts
+++ b/src/agent/streaming/lifecycle/live-adapter.test.ts
@@ -51,6 +51,7 @@ describe("stream lifecycle live adapter", () => {
       {
         type: "tool_input_status",
         toolCallId: "local-1",
+        toolCallName: "create_file",
         status: "pending_input",
       },
     ]).flatMap((frame) => adapter.encode(frame));
@@ -77,7 +78,7 @@ describe("stream lifecycle live adapter", () => {
       },
       {
         type: "data-tool-call-status",
-        data: { toolCallId: "local-1", status: "pending_input" },
+        data: { toolCallId: "local-1", toolCallName: "create_file", status: "pending_input" },
       },
     ]);
 

--- a/src/agent/streaming/lifecycle/live-adapter.ts
+++ b/src/agent/streaming/lifecycle/live-adapter.ts
@@ -42,6 +42,7 @@ export function createStreamLifecycleLiveAdapter(
             type: "data-tool-call-status",
             data: {
               toolCallId: frame.event.toolCallId,
+              toolCallName: frame.event.toolCallName,
               status: frame.event.status,
             },
           } as ChatStreamEvent]

--- a/src/agent/streaming/lifecycle/reducer.test.ts
+++ b/src/agent/streaming/lifecycle/reducer.test.ts
@@ -68,6 +68,33 @@ describe("stream lifecycle reducer", () => {
     }
   });
 
+  it("names the tool on the status telemetry it emits from a custom signal", () => {
+    let state = createInitialReducerState();
+    const events = [
+      { type: "tool_input_start", toolCallId: "tool-1", toolName: "create_file" },
+      {
+        type: "custom",
+        name: "tool-call-status",
+        data: { toolCallId: "tool-1", status: "pending_input" },
+      },
+    ] as const;
+    const frames = events.flatMap((event, index) => {
+      const reduced = reduceStreamSignal(state, protocol(event), index + 1);
+      state = reduced.state;
+      return reduced.frames;
+    });
+
+    assertEquals(
+      frames.filter((frame) => frame.class === "telemetry").map((frame) => frame.event),
+      [{
+        type: "tool_input_status",
+        toolCallId: "tool-1",
+        toolCallName: "create_file",
+        status: "pending_input",
+      }],
+    );
+  });
+
   it("records reducer-approved tool progress in the canonical snapshot", () => {
     let state = createInitialReducerState();
     state = reduceStreamSignal(

--- a/src/agent/streaming/lifecycle/reducer.ts
+++ b/src/agent/streaming/lifecycle/reducer.ts
@@ -212,11 +212,14 @@ export function reduceStreamSignal(
           typeof data.toolCallId === "string" &&
           (data.status === "pending_input" || data.status === "streaming_input")
         ) {
+          const toolCallId = data.toolCallId;
           emit({
             class: "telemetry",
             event: {
               type: "tool_input_status",
-              toolCallId: data.toolCallId,
+              toolCallId,
+              toolCallName: state.snapshot.tools.find((entry) => entry.id === toolCallId)?.name ??
+                null,
               status: data.status,
             },
           });

--- a/src/agent/streaming/lifecycle/runner.ts
+++ b/src/agent/streaming/lifecycle/runner.ts
@@ -182,6 +182,7 @@ export function runStreamLifecycle<TProviderPart>(
             const frame = sequenceTelemetry(reducer, {
               type: "tool_input_status",
               toolCallId,
+              toolCallName: tool.name,
               status: tool.phase === "input_streaming" ? "streaming_input" : "pending_input",
             }, elapsedMs());
             notifyObserver(() => observer?.onFrame(frame));

--- a/src/agent/streaming/lifecycle/types.ts
+++ b/src/agent/streaming/lifecycle/types.ts
@@ -141,6 +141,7 @@ export type StreamTelemetryEvent =
   | {
     type: "tool_input_status";
     toolCallId: string;
+    toolCallName: string | null;
     status: "pending_input" | "streaming_input";
   }
   | { type: "live_heartbeat" }

--- a/src/chat/ag-ui-helpers.ts
+++ b/src/chat/ag-ui-helpers.ts
@@ -19,27 +19,49 @@ export function toRenderableCustomChunk(value: unknown): ParsedRenderableCustomC
   }
 
   if (value.type === "source-url" && typeof value.url === "string") {
+    const resolvedSourceId = typeof value.sourceId === "string" && value.sourceId.length > 0
+      ? value.sourceId
+      : value.url;
+    // Only a genuinely absent title falls back to the resolved source id --
+    // the same fallback, under the same condition, the AG-UI decoder's
+    // native UrlCited case applies. This function decodes the reconstructed
+    // CUSTOM twin a replayed native URL_CITED durable record produces too,
+    // and that record never carries an empty title
+    // (native-run-events.ts's omitInvalidOptionalStrings drops it, I1), so
+    // it must render the same fallback the live frame does. A
+    // present-but-wrong-typed title is still dropped rather than defaulted,
+    // matching this function's own `typeof === "string"` guard on every
+    // other optional field, and matching the native decoder's own
+    // absent-vs-wrong-typed distinction so the two paths render the same
+    // chat event for the same logical value.
+    const resolvedTitle = value.title === undefined
+      ? resolvedSourceId
+      : typeof value.title === "string"
+      ? value.title
+      : undefined;
     return {
       type: "source-url",
-      sourceId: typeof value.sourceId === "string" && value.sourceId.length > 0
-        ? value.sourceId
-        : value.url,
+      sourceId: resolvedSourceId,
       url: value.url,
-      ...(typeof value.title === "string" ? { title: value.title } : {}),
+      ...(resolvedTitle !== undefined ? { title: resolvedTitle } : {}),
     };
   }
 
   if (
     value.type === "source-document" &&
     typeof value.sourceId === "string" &&
-    typeof value.mediaType === "string" &&
-    typeof value.title === "string"
+    typeof value.mediaType === "string"
   ) {
+    // ChatSourceDocumentUiPart.title is a required chat UI field, unlike
+    // source-url's title or this event's own filename, so an absent title
+    // falls back to the source id instead of making the whole citation
+    // unrenderable -- see the source-url case above for why this must hold
+    // for a replayed native DOCUMENT_CITED record too, not just a live one.
     return {
       type: "source-document",
       sourceId: value.sourceId,
       mediaType: value.mediaType,
-      title: value.title,
+      title: typeof value.title === "string" ? value.title : value.sourceId,
       ...(typeof value.filename === "string" ? { filename: value.filename } : {}),
     };
   }

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -16,6 +16,7 @@ import {
   buildUrlCitedEvent,
   NATIVE_RUN_EVENTS,
 } from "#veryfront/agent/ag-ui/native-run-events.ts";
+import { formatAgUiEvent } from "#veryfront/internal-agents/ag-ui-sse.ts";
 import { AG_UI_EVENT_TIMING_STAMP_FIELDS } from "#veryfront/agent/ag-ui/encoder.ts";
 import { readConversationRunLifecycleFrames } from "#veryfront/agent/conversation/legacy-run-read-adapter.ts";
 import {
@@ -695,6 +696,44 @@ describe("chat/ag-ui", () => {
       },
     ]);
   });
+  for (const schemaBacked of [true, false]) {
+    for (const validationMode of ["strict", "permissive"] as const) {
+      it(`accepts optional tool names with schema=${schemaBacked} in ${validationMode} mode`, () => {
+        ensureTestSchemaValidator();
+        const frames = [{}, { toolCallName: null }, { toolCallName: "create_file" }].map(
+          (name) => {
+            const payload = { toolCallId: "tool-1", status: "pending_input", ...name };
+            return {
+              payload,
+              wire: new TextDecoder().decode(formatAgUiEvent("ToolCallStatusChanged", payload)),
+            };
+          },
+        );
+        if (!schemaBacked) unregister("SchemaValidator");
+        try {
+          for (const { payload, wire } of frames) {
+            const state = createAgUiChatEventDecoderState({ validationMode });
+            assertEquals(
+              decodeAgUiSseChunk(state, wire).events.flatMap((entry) => entry.chatEvents),
+              [{ type: "data-tool-call-status", data: payload }],
+            );
+          }
+          const invalid = 'event: ToolCallStatusChanged\ndata: {"toolCallId":"tool-1",' +
+            '"status":"pending_input","toolCallName":42}\n\n';
+          const decodeInvalid = () =>
+            decodeAgUiSseChunk(
+              createAgUiChatEventDecoderState({ validationMode }),
+              invalid,
+            );
+          if (validationMode === "strict") assertThrows(decodeInvalid);
+          else assertEquals(decodeInvalid().events, []);
+        } finally {
+          ensureTestSchemaValidator();
+        }
+      });
+    }
+  }
+
   it("decodes native run event frames into the chunks their custom twins produced", () => {
     ensureTestSchemaValidator();
     const state = createAgUiChatEventDecoderState({ validationMode: "strict" });

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -6,10 +6,17 @@ import {
   createAgUiRunErrorEvent,
   createAgUiSseErrorResponse,
 } from "#veryfront/agent/ag-ui/host-support.ts";
+// Test-only imports from the agent tree: this file is not part of the
+// client bundle graph that `deno task lint:client-bundle` audits, so these
+// pin the decoder's copied wire-name and timing-stamp-field lists against
+// their sources of truth without widening the browser bundle.
+import { NATIVE_RUN_EVENTS } from "#veryfront/agent/ag-ui/native-run-events.ts";
+import { AG_UI_EVENT_TIMING_STAMP_FIELDS } from "#veryfront/agent/ag-ui/encoder.ts";
 import {
   createAgUiChatEventDecoderState,
   decodeAgUiSseChunk,
   flushAgUiSseChunk,
+  getAgUiWireEventNameSchema,
   mapAgUiRuntimeMessagesToChatUiMessages,
   parseSseEvent,
 } from "./ag-ui.ts";
@@ -682,84 +689,6 @@ describe("chat/ag-ui", () => {
       },
     ]);
   });
-});
-
-describe("chat/ag-ui without a registered SchemaValidator", () => {
-  // The browser chat client decodes AG-UI frames before any schema adapter is
-  // registered, so the hand-rolled validator has to reach the same canonical
-  // events the zod-backed schema produces.
-  it("decodes the same canonical events through the hand-rolled validator", () => {
-    unregister("SchemaValidator");
-    try {
-      const state = createAgUiChatEventDecoderState();
-      const result = decodeAgUiSseChunk(
-        state,
-        [
-          "event: RunStarted",
-          'data: {"runId":"run-1","threadId":"thread-1","agentId":"veryfront","agentName":"Veryfront","agent_avatar_url":"https://cdn.example.com/agents/veryfront.svg"}',
-          "",
-          "event: TextMessageStart",
-          'data: {"messageId":"msg-1","contentId":"text:0","role":"assistant"}',
-          "",
-          "event: TextMessageContent",
-          'data: {"messageId":"msg-1","contentId":"text:0","delta":"Hello"}',
-          "",
-          "event: ToolCallStart",
-          'data: {"toolCallId":"tool-1","toolCallName":"load_skill"}',
-          "",
-          "event: ToolCallArgs",
-          'data: {"toolCallId":"tool-1","delta":"{}"}',
-          "",
-          "",
-        ].join("\n"),
-      );
-
-      assertEquals(
-        result.events.flatMap((entry) => entry.chatEvents),
-        [
-          {
-            type: "start",
-            messageMetadata: {
-              agentId: "veryfront",
-              agentName: "Veryfront",
-              agent_avatar_url: "https://cdn.example.com/agents/veryfront.svg",
-              runId: "run-1",
-              threadId: "thread-1",
-            },
-          },
-          { type: "text-start", id: "msg-1", contentId: "text:0" },
-          { type: "text-delta", id: "msg-1", contentId: "text:0", delta: "Hello" },
-          {
-            type: "tool-input-start",
-            toolCallId: "tool-1",
-            toolName: "load_skill",
-            providerExecuted: true,
-          },
-          { type: "tool-input-delta", toolCallId: "tool-1", inputTextDelta: "{}" },
-        ],
-        "schemaless decoding must produce the same canonical events",
-      );
-    } finally {
-      ensureTestSchemaValidator();
-    }
-  });
-
-  it("rejects a Custom frame that carries no value", () => {
-    unregister("SchemaValidator");
-    try {
-      const state = createAgUiChatEventDecoderState();
-      const result = decodeAgUiSseChunk(state, 'event: Custom\ndata: {"name":"progress"}\n\n');
-
-      assertEquals(
-        result.events,
-        [],
-        "Custom without value must be rejected by the hand-rolled validator",
-      );
-    } finally {
-      ensureTestSchemaValidator();
-    }
-  });
-
   it("decodes native run event frames into the chunks their custom twins produced", () => {
     ensureTestSchemaValidator();
     const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
@@ -905,6 +834,24 @@ describe("chat/ag-ui without a registered SchemaValidator", () => {
     ]);
   });
 
+  it("falls back to the url as sourceId for a URL citation missing one", () => {
+    ensureTestSchemaValidator();
+    // toRenderableCustomChunk falls back to url when sourceId is absent or
+    // empty. This producer's buildUrlCitedEvent always sets sourceId, so
+    // this is unreachable today, but a replayed or hand-built frame must
+    // still match the twin instead of throwing in strict mode.
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const frames = [
+      'event: UrlCited\ndata: {"url":"https://example.com/a"}\n\n',
+      'event: UrlCited\ndata: {"sourceId":"","url":"https://example.com/b"}\n\n',
+    ].join("");
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      { type: "source-url", sourceId: "https://example.com/a", url: "https://example.com/a" },
+      { type: "source-url", sourceId: "https://example.com/b", url: "https://example.com/b" },
+    ]);
+  });
+
   it("renders or falls back on a wrong-typed optional field instead of rejecting the frame", () => {
     ensureTestSchemaValidator();
     // The encoder never type-checks title/filename/url before sending them,
@@ -963,5 +910,195 @@ describe("chat/ag-ui without a registered SchemaValidator", () => {
         data: { type: "file", mediaType: "application/pdf" },
       },
     ]);
+  });
+
+  it("decodes every native run event wire name NATIVE_RUN_EVENTS defines", () => {
+    ensureTestSchemaValidator();
+    // NATIVE_RUN_EVENTS (src/agent/ag-ui/native-run-events.ts) is the
+    // producer's source of truth for the seven native wire names; this
+    // decoder keeps its own copy in AG_UI_WIRE_EVENT_NAMES rather than
+    // importing that module, to keep the agent tree off the client bundle
+    // graph. Nothing else catches the two lists drifting apart: an eighth
+    // native type added there would be silently dropped here, which is the
+    // exact failure P9 exists to prevent.
+    for (const { wireName } of NATIVE_RUN_EVENTS) {
+      const parsed = getAgUiWireEventNameSchema().safeParse(wireName);
+      assertEquals(
+        parsed.success,
+        true,
+        `AG_UI_WIRE_EVENT_NAMES in src/chat/ag-ui.ts is missing native wire name "${wireName}"; ` +
+          "add it there or this decoder silently drops the frame",
+      );
+    }
+  });
+
+  it("keeps its timing-stamp strip list in sync with the encoder's stamped fields", () => {
+    ensureTestSchemaValidator();
+    // AG_UI_EVENT_TIMING_STAMP_FIELDS (src/agent/ag-ui/encoder.ts) names
+    // every field stampAgUiEventTiming stamps onto a live event's flat
+    // payload. The decoder's stripAgUiTimingStamps re-hardcodes that same
+    // list so it can strip them from a reconstructed legacy data chunk; this
+    // drives every stamped field through the decoder and asserts none of
+    // them survive, so a third stamped field added later fails a test
+    // instead of leaking into `data` the way elapsedMs/emittedAt already
+    // did once on the durable-record read path (commit 3ee902fb12).
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const stampedFields = Object.fromEntries(
+      AG_UI_EVENT_TIMING_STAMP_FIELDS.map((field) => [field, 1]),
+    );
+    const payload = JSON.stringify({
+      toolCallId: "tool-1",
+      toolCallName: "create_file",
+      status: "pending_input",
+      ...stampedFields,
+    });
+    const result = decodeAgUiSseChunk(
+      state,
+      `event: ToolCallStatusChanged\ndata: ${payload}\n\n`,
+    );
+
+    const [event] = result.events.flatMap((entry) => entry.chatEvents);
+    assertExists(event);
+    const data = (event as { data: Record<string, unknown> }).data;
+    for (const field of AG_UI_EVENT_TIMING_STAMP_FIELDS) {
+      assertEquals(
+        Object.hasOwn(data, field),
+        false,
+        `stripAgUiTimingStamps in src/chat/ag-ui.ts must also strip "${field}"`,
+      );
+    }
+  });
+});
+
+describe("chat/ag-ui without a registered SchemaValidator", () => {
+  // The browser chat client decodes AG-UI frames before any schema adapter is
+  // registered, so the hand-rolled validator has to reach the same canonical
+  // events the zod-backed schema produces.
+  it("decodes the same canonical events through the hand-rolled validator", () => {
+    unregister("SchemaValidator");
+    try {
+      const state = createAgUiChatEventDecoderState();
+      const result = decodeAgUiSseChunk(
+        state,
+        [
+          "event: RunStarted",
+          'data: {"runId":"run-1","threadId":"thread-1","agentId":"veryfront","agentName":"Veryfront","agent_avatar_url":"https://cdn.example.com/agents/veryfront.svg"}',
+          "",
+          "event: TextMessageStart",
+          'data: {"messageId":"msg-1","contentId":"text:0","role":"assistant"}',
+          "",
+          "event: TextMessageContent",
+          'data: {"messageId":"msg-1","contentId":"text:0","delta":"Hello"}',
+          "",
+          "event: ToolCallStart",
+          'data: {"toolCallId":"tool-1","toolCallName":"load_skill"}',
+          "",
+          "event: ToolCallArgs",
+          'data: {"toolCallId":"tool-1","delta":"{}"}',
+          "",
+          "",
+        ].join("\n"),
+      );
+
+      assertEquals(
+        result.events.flatMap((entry) => entry.chatEvents),
+        [
+          {
+            type: "start",
+            messageMetadata: {
+              agentId: "veryfront",
+              agentName: "Veryfront",
+              agent_avatar_url: "https://cdn.example.com/agents/veryfront.svg",
+              runId: "run-1",
+              threadId: "thread-1",
+            },
+          },
+          { type: "text-start", id: "msg-1", contentId: "text:0" },
+          { type: "text-delta", id: "msg-1", contentId: "text:0", delta: "Hello" },
+          {
+            type: "tool-input-start",
+            toolCallId: "tool-1",
+            toolName: "load_skill",
+            providerExecuted: true,
+          },
+          { type: "tool-input-delta", toolCallId: "tool-1", inputTextDelta: "{}" },
+        ],
+        "schemaless decoding must produce the same canonical events",
+      );
+    } finally {
+      ensureTestSchemaValidator();
+    }
+  });
+
+  it("rejects a Custom frame that carries no value", () => {
+    unregister("SchemaValidator");
+    try {
+      const state = createAgUiChatEventDecoderState();
+      const result = decodeAgUiSseChunk(state, 'event: Custom\ndata: {"name":"progress"}\n\n');
+
+      assertEquals(
+        result.events,
+        [],
+        "Custom without value must be rejected by the hand-rolled validator",
+      );
+    } finally {
+      ensureTestSchemaValidator();
+    }
+  });
+
+  it("decodes native run event frames through the hand-rolled validator too", () => {
+    // The seven native arms in isValidAgUiPayload only run on this path, so
+    // the zod-backed coverage above does not exercise them at all. Reuse the
+    // same seven-frame string the schema-validated twin-equality test uses.
+    unregister("SchemaValidator");
+    try {
+      const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+      const frames = [
+        'event: ToolCallStatusChanged\ndata: {"toolCallId":"tool-1","toolCallName":"create_file",' +
+        '"status":"pending_input"}\n\n',
+        'event: UrlCited\ndata: {"sourceId":"web-1","url":"https://example.com/a","title":"A"}\n\n',
+        'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown",' +
+        '"title":"Report"}\n\n',
+        'event: FileAttached\ndata: {"url":"https://cdn.example.com/a.pdf",' +
+        '"mediaType":"application/pdf"}\n\n',
+        'event: InputRequestCreated\ndata: {"inputRequest":{"id":"req-1"}}\n\n',
+        'event: InputRequestUpdated\ndata: {"inputRequest":{"id":"req-1"}}\n\n',
+        'event: ChildRunStatusChanged\ndata: {"toolCallId":"t","childRunId":"r",' +
+        '"status":"running"}\n\n',
+      ].join("");
+
+      assertEquals(
+        decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents),
+        [
+          {
+            type: "data-tool-call-status",
+            data: { toolCallId: "tool-1", toolCallName: "create_file", status: "pending_input" },
+          },
+          { type: "source-url", sourceId: "web-1", url: "https://example.com/a", title: "A" },
+          {
+            type: "source-document",
+            sourceId: "doc-1",
+            mediaType: "text/markdown",
+            title: "Report",
+          },
+          { type: "file", url: "https://cdn.example.com/a.pdf", mediaType: "application/pdf" },
+          {
+            type: "data-veryfront.input_request.lifecycle",
+            data: { action: "created", inputRequest: { id: "req-1" } },
+          },
+          {
+            type: "data-veryfront.input_request.lifecycle",
+            data: { action: "updated", inputRequest: { id: "req-1" } },
+          },
+          {
+            type: "data-veryfront.invoke_agent.lifecycle",
+            data: { toolCallId: "t", childRunId: "r", status: "running" },
+          },
+        ],
+        "the hand-rolled validator must decode native frames the same way the zod schema does",
+      );
+    } finally {
+      ensureTestSchemaValidator();
+    }
   });
 });

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -10,7 +10,11 @@ import {
 // client bundle graph that `deno task lint:client-bundle` audits, so these
 // pin the decoder's copied wire-name and timing-stamp-field lists against
 // their sources of truth without widening the browser bundle.
-import { NATIVE_RUN_EVENTS } from "#veryfront/agent/ag-ui/native-run-events.ts";
+import {
+  buildDocumentCitedEvent,
+  buildFileAttachedEvent,
+  NATIVE_RUN_EVENTS,
+} from "#veryfront/agent/ag-ui/native-run-events.ts";
 import { AG_UI_EVENT_TIMING_STAMP_FIELDS } from "#veryfront/agent/ag-ui/encoder.ts";
 import {
   createAgUiChatEventDecoderState,
@@ -762,11 +766,14 @@ describe("chat/ag-ui", () => {
 
   it("accepts empty-string title and filename like the legacy custom mapping", () => {
     ensureTestSchemaValidator();
-    // The native builders pass title/filename through unguarded, so an empty
-    // string is a value the wire can legitimately carry. The legacy `Custom`
-    // twin only ever checked `typeof value.title === "string"`, with no
-    // length requirement, so the native decoder must accept it too instead
-    // of dropping the whole frame.
+    // The native builders pass title/filename through unguarded on the live
+    // wire frame (native-run-events.ts keeps this decoder's own render gate
+    // intact -- see the round-trip test below), so an empty string is a
+    // value the wire can legitimately carry. Only the durable record drops
+    // one, since the API's z.string().min(1).optional() catalog rejects it
+    // there. The legacy `Custom` twin only ever checked
+    // `typeof value.title === "string"`, with no length requirement, so the
+    // native decoder must accept it too instead of dropping the whole frame.
     const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
     const frames = [
       'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown",' +
@@ -783,6 +790,43 @@ describe("chat/ag-ui", () => {
         filename: "",
       },
       { type: "file", url: "", mediaType: "application/pdf", filename: "" },
+    ]);
+  });
+
+  it("still renders a citation/attachment the builders produced with an empty title/url", () => {
+    // Encoder-to-decoder round trip, not a hand-built frame like the test
+    // above. This decoder's DocumentCited case uses a string title as its
+    // gate for rendering `source-document` at all; the FileAttached case
+    // does the same with url. buildDocumentCitedEvent never lets title be
+    // empty in the first place -- it falls back to the source id -- so the
+    // citation always renders. buildFileAttachedEvent's live frame still
+    // carries an empty url through unchanged (only its durable record drops
+    // it, for the API's append route), so the attachment renders too;
+    // dropping it from the live frame instead, as an earlier version of
+    // this fix did, would make the attachment disappear from the chat's
+    // sources.
+    ensureTestSchemaValidator();
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+
+    const documentFrame = buildDocumentCitedEvent({
+      type: "source-document",
+      sourceId: "doc-1",
+      mediaType: "text/markdown",
+      title: "",
+    }).live;
+    const fileFrame = buildFileAttachedEvent({
+      type: "file",
+      mediaType: "application/pdf",
+      url: "",
+    }).live;
+    const frames = [
+      `event: ${documentFrame.event}\ndata: ${JSON.stringify(documentFrame.payload)}\n\n`,
+      `event: ${fileFrame.event}\ndata: ${JSON.stringify(fileFrame.payload)}\n\n`,
+    ].join("");
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown", title: "doc-1" },
+      { type: "file", url: "", mediaType: "application/pdf" },
     ]);
   });
 

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -13,9 +13,11 @@ import {
 import {
   buildDocumentCitedEvent,
   buildFileAttachedEvent,
+  buildUrlCitedEvent,
   NATIVE_RUN_EVENTS,
 } from "#veryfront/agent/ag-ui/native-run-events.ts";
 import { AG_UI_EVENT_TIMING_STAMP_FIELDS } from "#veryfront/agent/ag-ui/encoder.ts";
+import { readConversationRunLifecycleFrames } from "#veryfront/agent/conversation/legacy-run-read-adapter.ts";
 import {
   createAgUiChatEventDecoderState,
   decodeAgUiSseChunk,
@@ -733,30 +735,33 @@ describe("chat/ag-ui", () => {
     ]);
   });
 
-  it("falls back to a data chunk when a citation or attachment cannot render", () => {
+  it("falls back to a data chunk when an attachment cannot render", () => {
     ensureTestSchemaValidator();
     const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
-    // toRenderableCustomChunk returned null for these two, and the Custom arm
-    // fell through to a data chunk. The native arms must do the same, or the
-    // renderer gets a part with a field it requires missing.
+    // toRenderableCustomChunk returned null for a file with no url, and the
+    // Custom arm fell through to a data chunk. The native FileAttached arm
+    // does the same: unlike DocumentCited's title (falls back to the source
+    // id, since ChatSourceDocumentUiPart.title is required) or UrlCited's
+    // title (optional, simply omitted), a url has no safe non-empty
+    // fallback -- a placeholder would be an actively misleading, possibly
+    // broken link -- so a missing one still has to fall back to the raw
+    // chunk instead. See "treats a chunk's empty file url the same as a
+    // missing one" for the encoder-to-decoder round trip, and "still
+    // renders a citation despite the encoder dropping its empty title" for
+    // DocumentCited/UrlCited's fallback instead.
     //
     // The Custom twin's fallback `data` is the whole original chunk object,
-    // which still carries its own `type` (e.g. "source-document") because
-    // that object is what toRenderableCustomChunk received as `value` before
-    // it returned null. The native wire payload never carries that field —
-    // the encoder's `toFrame` strips it, since the AG-UI event name already
+    // which still carries its own `type` (e.g. "file") because that object
+    // is what toRenderableCustomChunk received as `value` before it
+    // returned null. The native wire payload never carries that field — the
+    // encoder's `toFrame` strips it, since the AG-UI event name already
     // names the chunk type — so the fallback here restores it to stay
     // byte-identical to the twin's fallback chunk.
     const frames = [
-      'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown"}\n\n',
       'event: FileAttached\ndata: {"mediaType":"application/pdf","filename":"a.pdf"}\n\n',
     ].join("");
 
     assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
-      {
-        type: "data-source-document",
-        data: { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown" },
-      },
       {
         type: "data-file",
         data: { type: "file", mediaType: "application/pdf", filename: "a.pdf" },
@@ -766,14 +771,16 @@ describe("chat/ag-ui", () => {
 
   it("accepts empty-string title and filename like the legacy custom mapping", () => {
     ensureTestSchemaValidator();
-    // The native builders pass title/filename through unguarded on the live
-    // wire frame (native-run-events.ts keeps this decoder's own render gate
-    // intact -- see the round-trip test below), so an empty string is a
-    // value the wire can legitimately carry. Only the durable record drops
-    // one, since the API's z.string().min(1).optional() catalog rejects it
-    // there. The legacy `Custom` twin only ever checked
+    // The native builders drop an empty title/filename/url before either
+    // wire shape ever carries it (native-run-events.ts's omitEmptyStrings,
+    // I1), so this scenario is unreachable from this producer today -- but a
+    // replayed or hand-built frame could still carry a literal empty string,
+    // and the legacy `Custom` twin only ever checked
     // `typeof value.title === "string"`, with no length requirement, so the
-    // native decoder must accept it too instead of dropping the whole frame.
+    // native decoder must stay lenient and accept it too instead of
+    // dropping the whole frame or substituting a fallback for a value that
+    // is, unlike an absent one, present and valid as far as this decoder is
+    // concerned.
     const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
     const frames = [
       'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown",' +
@@ -793,18 +800,16 @@ describe("chat/ag-ui", () => {
     ]);
   });
 
-  it("still renders a citation/attachment the builders produced with an empty title/url", () => {
-    // Encoder-to-decoder round trip, not a hand-built frame like the test
-    // above. This decoder's DocumentCited case uses a string title as its
-    // gate for rendering `source-document` at all; the FileAttached case
-    // does the same with url. buildDocumentCitedEvent never lets title be
-    // empty in the first place -- it falls back to the source id -- so the
-    // citation always renders. buildFileAttachedEvent's live frame still
-    // carries an empty url through unchanged (only its durable record drops
-    // it, for the API's append route), so the attachment renders too;
-    // dropping it from the live frame instead, as an earlier version of
-    // this fix did, would make the attachment disappear from the chat's
-    // sources.
+  it("still renders a citation despite the encoder dropping its empty title", () => {
+    // Encoder-to-decoder round trip, not a hand-built frame like the tests
+    // above and below: buildDocumentCitedEvent/buildUrlCitedEvent drop an
+    // empty title from the one payload both shapes share (I1), so the live
+    // wire frame never carries it either -- the citation still has to
+    // render as if it had one. DocumentCited's decoder case falls back to
+    // the citation's own source id because ChatSourceDocumentUiPart.title is
+    // required; UrlCited's does the same for consistency, even though its
+    // own title is optional and an absent one would otherwise just be
+    // omitted.
     ensureTestSchemaValidator();
     const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
 
@@ -814,20 +819,124 @@ describe("chat/ag-ui", () => {
       mediaType: "text/markdown",
       title: "",
     }).live;
-    const fileFrame = buildFileAttachedEvent({
-      type: "file",
-      mediaType: "application/pdf",
-      url: "",
+    const urlFrame = buildUrlCitedEvent({
+      type: "source-url",
+      sourceId: "web-1",
+      url: "https://example.com/a",
+      title: "",
     }).live;
     const frames = [
       `event: ${documentFrame.event}\ndata: ${JSON.stringify(documentFrame.payload)}\n\n`,
-      `event: ${fileFrame.event}\ndata: ${JSON.stringify(fileFrame.payload)}\n\n`,
+      `event: ${urlFrame.event}\ndata: ${JSON.stringify(urlFrame.payload)}\n\n`,
     ].join("");
 
     assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
       { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown", title: "doc-1" },
-      { type: "file", url: "", mediaType: "application/pdf" },
+      { type: "source-url", sourceId: "web-1", url: "https://example.com/a", title: "web-1" },
     ]);
+  });
+
+  it("still renders a replayed citation despite the durable record dropping its empty title", () => {
+    // Compatibility-replay round trip, not the live wire frame like the test
+    // above: a durable DOCUMENT_CITED/URL_CITED record with an empty title
+    // (native-run-events.ts drops it, I1) gets read back by
+    // legacy-run-read-adapter.ts as a legacy `Custom`-wrapped twin
+    // (`{type: "custom", name, data}` lifecycle frames). Encoding that
+    // straight back into a live AG-UI wire event re-natives it through
+    // buildNativeRunEventFrame (lifecycle-adapter.ts's own "custom" case),
+    // which exercises the same native decoder arm the test above already
+    // covers -- so this constructs the literal `Custom` wire frame the twin
+    // itself represents instead, the shape a compatibility reader that does
+    // NOT re-native would emit. That goes through this decoder's `Custom`
+    // arm and toRenderableCustomChunk (ag-ui-helpers.ts), a completely
+    // different code path from the native arms' own title fallback. Both
+    // paths must fall back to the source id the same way, or a citation
+    // that rendered live disappears under compatibility replay.
+    ensureTestSchemaValidator();
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+
+    const documentDurable = buildDocumentCitedEvent({
+      type: "source-document",
+      sourceId: "doc-1",
+      mediaType: "text/markdown",
+      title: "",
+    }).durable;
+    const urlDurable = buildUrlCitedEvent({
+      type: "source-url",
+      sourceId: "web-1",
+      url: "https://example.com/a",
+      title: "",
+    }).durable;
+    const read = readConversationRunLifecycleFrames({
+      streamProtocolVersion: 2,
+      events: [
+        {
+          ...documentDurable,
+          stream_protocol_version: 2,
+          logical_sequence: 1,
+          idempotency_key: "replay:document",
+        },
+        {
+          ...urlDurable,
+          stream_protocol_version: 2,
+          logical_sequence: 2,
+          idempotency_key: "replay:url",
+        },
+      ],
+    });
+    assertEquals(read.status, "ok");
+    if (read.status !== "ok") return;
+
+    const customTwins = read.frames
+      .map((frame) => frame.event)
+      .filter((event): event is { type: "custom"; name: string; data: unknown } =>
+        event.type === "custom"
+      );
+    assertEquals(customTwins.length, 2, "both records must read back as Custom twins");
+
+    const frames = customTwins
+      .map((twin) =>
+        `event: Custom\ndata: ${JSON.stringify({ name: twin.name, value: twin.data })}\n\n`
+      )
+      .join("");
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown", title: "doc-1" },
+      { type: "source-url", sourceId: "web-1", url: "https://example.com/a", title: "web-1" },
+    ]);
+  });
+
+  it("treats a chunk's empty file url the same as a missing one", () => {
+    // buildFileAttachedEvent drops an empty url from the one payload both
+    // shapes share (I1), so it never reaches the wire as "" -- once encoded,
+    // a chunk whose url was originally empty is indistinguishable from one
+    // that never had a url at all, and the FileAttached decoder case falls
+    // back to a raw data-file chunk for both, exactly as
+    // toRenderableCustomChunk did for the legacy Custom wrapper's `file`
+    // value with no url.
+    ensureTestSchemaValidator();
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+
+    const emptyUrlFrame = buildFileAttachedEvent({
+      type: "file",
+      mediaType: "application/pdf",
+      url: "",
+    }).live;
+    const noUrlFrame = buildFileAttachedEvent({
+      type: "file",
+      mediaType: "application/pdf",
+    }).live;
+    const frames = [
+      `event: ${emptyUrlFrame.event}\ndata: ${JSON.stringify(emptyUrlFrame.payload)}\n\n`,
+      `event: ${noUrlFrame.event}\ndata: ${JSON.stringify(noUrlFrame.payload)}\n\n`,
+    ].join("");
+
+    const decoded = decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents);
+    assertEquals(
+      decoded[0],
+      { type: "data-file", data: { type: "file", mediaType: "application/pdf" } },
+    );
+    assertEquals(decoded[0], decoded[1], "an empty url and a missing url must decode identically");
   });
 
   it("tolerates a null optional field the way the legacy custom mapping did", () => {
@@ -836,9 +945,10 @@ describe("chat/ag-ui", () => {
     // received them, including an explicit null, and the legacy `Custom`
     // twin's `typeof value.field === "string"` guard never rejected a null
     // value outright — it just omitted the field. A renderable citation or
-    // attachment with a null filename must still render, and a null field
-    // on an otherwise-unrenderable one must not be dropped from the fallback
-    // data either.
+    // attachment with a null filename must still render, a null title on a
+    // DocumentCited falls back to the source id the same way an absent one
+    // does, and a null field on an otherwise-unrenderable FileAttached must
+    // not be dropped from the fallback data either.
     const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
     const frames = [
       'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown",' +
@@ -846,20 +956,17 @@ describe("chat/ag-ui", () => {
       'event: FileAttached\ndata: {"url":"https://cdn.example.com/a.pdf",' +
       '"mediaType":"application/pdf","filename":null}\n\n',
       'event: DocumentCited\ndata: {"sourceId":"doc-2","mediaType":"text/markdown",' +
-      '"filename":null}\n\n',
+      '"title":null}\n\n',
+      'event: FileAttached\ndata: {"mediaType":"application/pdf","filename":null}\n\n',
     ].join("");
 
     assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
       { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown", title: "Report" },
       { type: "file", url: "https://cdn.example.com/a.pdf", mediaType: "application/pdf" },
+      { type: "source-document", sourceId: "doc-2", mediaType: "text/markdown", title: "doc-2" },
       {
-        type: "data-source-document",
-        data: {
-          type: "source-document",
-          sourceId: "doc-2",
-          mediaType: "text/markdown",
-          filename: null,
-        },
+        type: "data-file",
+        data: { type: "file", mediaType: "application/pdf", filename: null },
       },
     ]);
   });
@@ -878,6 +985,48 @@ describe("chat/ag-ui", () => {
     ]);
   });
 
+  it("keeps the Custom twin's URL citation title behavior consistent with the native decoder", () => {
+    // Regression guard: toRenderableCustomChunk (ag-ui-helpers.ts) decodes
+    // the reconstructed CUSTOM twin a replayed native URL_CITED record
+    // produces, while this decoder's own UrlCited case decodes the live
+    // wire frame -- both must resolve title the same way for the same
+    // logical value (absent falls back to the source id; present-but-wrong-typed
+    // is dropped; a real string is kept), or a citation renders differently
+    // depending on whether it was seen live or replayed.
+    ensureTestSchemaValidator();
+
+    for (const title of [undefined, null, 42, { unexpected: true }, "Reference"]) {
+      const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+      const nativePayload: Record<string, unknown> = {
+        sourceId: "web-1",
+        url: "https://example.com/a",
+      };
+      const customValue: Record<string, unknown> = {
+        type: "source-url",
+        sourceId: "web-1",
+        url: "https://example.com/a",
+      };
+      if (title !== undefined) {
+        nativePayload.title = title;
+        customValue.title = title;
+      }
+
+      const frames = [
+        `event: UrlCited\ndata: ${JSON.stringify(nativePayload)}\n\n`,
+        `event: Custom\ndata: ${JSON.stringify({ name: "source-url", value: customValue })}\n\n`,
+      ].join("");
+
+      const [nativeEvent, customEvent] = decodeAgUiSseChunk(state, frames).events.flatMap((
+        entry,
+      ) => entry.chatEvents);
+      assertEquals(
+        customEvent,
+        nativeEvent,
+        `native and Custom decoding must agree for title ${JSON.stringify(title)}`,
+      );
+    }
+  });
+
   it("falls back to the url as sourceId for a URL citation missing one", () => {
     ensureTestSchemaValidator();
     // toRenderableCustomChunk falls back to url when sourceId is absent or
@@ -891,8 +1040,18 @@ describe("chat/ag-ui", () => {
     ].join("");
 
     assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
-      { type: "source-url", sourceId: "https://example.com/a", url: "https://example.com/a" },
-      { type: "source-url", sourceId: "https://example.com/b", url: "https://example.com/b" },
+      {
+        type: "source-url",
+        sourceId: "https://example.com/a",
+        url: "https://example.com/a",
+        title: "https://example.com/a",
+      },
+      {
+        type: "source-url",
+        sourceId: "https://example.com/b",
+        url: "https://example.com/b",
+        title: "https://example.com/b",
+      },
     ]);
   });
 
@@ -946,8 +1105,10 @@ describe("chat/ag-ui", () => {
         data: { toolCallId: "t", childRunId: "r", status: "running" },
       },
       {
-        type: "data-source-document",
-        data: { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown" },
+        type: "source-document",
+        sourceId: "doc-1",
+        mediaType: "text/markdown",
+        title: "doc-1",
       },
       {
         type: "data-file",

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -759,4 +759,209 @@ describe("chat/ag-ui without a registered SchemaValidator", () => {
       ensureTestSchemaValidator();
     }
   });
+
+  it("decodes native run event frames into the chunks their custom twins produced", () => {
+    ensureTestSchemaValidator();
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const frames = [
+      'event: ToolCallStatusChanged\ndata: {"toolCallId":"tool-1","toolCallName":"create_file",' +
+      '"status":"pending_input"}\n\n',
+      'event: UrlCited\ndata: {"sourceId":"web-1","url":"https://example.com/a","title":"A"}\n\n',
+      'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown",' +
+      '"title":"Report"}\n\n',
+      'event: FileAttached\ndata: {"url":"https://cdn.example.com/a.pdf",' +
+      '"mediaType":"application/pdf"}\n\n',
+      'event: InputRequestCreated\ndata: {"inputRequest":{"id":"req-1"}}\n\n',
+      'event: InputRequestUpdated\ndata: {"inputRequest":{"id":"req-1"}}\n\n',
+      'event: ChildRunStatusChanged\ndata: {"toolCallId":"t","childRunId":"r",' +
+      '"status":"running"}\n\n',
+    ].join("");
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      {
+        type: "data-tool-call-status",
+        data: { toolCallId: "tool-1", toolCallName: "create_file", status: "pending_input" },
+      },
+      { type: "source-url", sourceId: "web-1", url: "https://example.com/a", title: "A" },
+      { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown", title: "Report" },
+      { type: "file", url: "https://cdn.example.com/a.pdf", mediaType: "application/pdf" },
+      {
+        type: "data-veryfront.input_request.lifecycle",
+        data: { action: "created", inputRequest: { id: "req-1" } },
+      },
+      {
+        type: "data-veryfront.input_request.lifecycle",
+        data: { action: "updated", inputRequest: { id: "req-1" } },
+      },
+      {
+        type: "data-veryfront.invoke_agent.lifecycle",
+        data: { toolCallId: "t", childRunId: "r", status: "running" },
+      },
+    ]);
+  });
+
+  it("falls back to a data chunk when a citation or attachment cannot render", () => {
+    ensureTestSchemaValidator();
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    // toRenderableCustomChunk returned null for these two, and the Custom arm
+    // fell through to a data chunk. The native arms must do the same, or the
+    // renderer gets a part with a field it requires missing.
+    //
+    // The Custom twin's fallback `data` is the whole original chunk object,
+    // which still carries its own `type` (e.g. "source-document") because
+    // that object is what toRenderableCustomChunk received as `value` before
+    // it returned null. The native wire payload never carries that field —
+    // the encoder's `toFrame` strips it, since the AG-UI event name already
+    // names the chunk type — so the fallback here restores it to stay
+    // byte-identical to the twin's fallback chunk.
+    const frames = [
+      'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown"}\n\n',
+      'event: FileAttached\ndata: {"mediaType":"application/pdf","filename":"a.pdf"}\n\n',
+    ].join("");
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      {
+        type: "data-source-document",
+        data: { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown" },
+      },
+      {
+        type: "data-file",
+        data: { type: "file", mediaType: "application/pdf", filename: "a.pdf" },
+      },
+    ]);
+  });
+
+  it("accepts empty-string title and filename like the legacy custom mapping", () => {
+    ensureTestSchemaValidator();
+    // The native builders pass title/filename through unguarded, so an empty
+    // string is a value the wire can legitimately carry. The legacy `Custom`
+    // twin only ever checked `typeof value.title === "string"`, with no
+    // length requirement, so the native decoder must accept it too instead
+    // of dropping the whole frame.
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const frames = [
+      'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown",' +
+      '"title":"","filename":""}\n\n',
+      'event: FileAttached\ndata: {"mediaType":"application/pdf","url":"","filename":""}\n\n',
+    ].join("");
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      {
+        type: "source-document",
+        sourceId: "doc-1",
+        mediaType: "text/markdown",
+        title: "",
+        filename: "",
+      },
+      { type: "file", url: "", mediaType: "application/pdf", filename: "" },
+    ]);
+  });
+
+  it("tolerates a null optional field the way the legacy custom mapping did", () => {
+    ensureTestSchemaValidator();
+    // `buildNativeRunEventFrame` preserves title/filename/url exactly as it
+    // received them, including an explicit null, and the legacy `Custom`
+    // twin's `typeof value.field === "string"` guard never rejected a null
+    // value outright — it just omitted the field. A renderable citation or
+    // attachment with a null filename must still render, and a null field
+    // on an otherwise-unrenderable one must not be dropped from the fallback
+    // data either.
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const frames = [
+      'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown",' +
+      '"title":"Report","filename":null}\n\n',
+      'event: FileAttached\ndata: {"url":"https://cdn.example.com/a.pdf",' +
+      '"mediaType":"application/pdf","filename":null}\n\n',
+      'event: DocumentCited\ndata: {"sourceId":"doc-2","mediaType":"text/markdown",' +
+      '"filename":null}\n\n',
+    ].join("");
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown", title: "Report" },
+      { type: "file", url: "https://cdn.example.com/a.pdf", mediaType: "application/pdf" },
+      {
+        type: "data-source-document",
+        data: {
+          type: "source-document",
+          sourceId: "doc-2",
+          mediaType: "text/markdown",
+          filename: null,
+        },
+      },
+    ]);
+  });
+
+  it("drops a non-string URL citation title instead of leaking it into the chat event", () => {
+    ensureTestSchemaValidator();
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const result = decodeAgUiSseChunk(
+      state,
+      'event: UrlCited\ndata: {"sourceId":"web-1","url":"https://example.com/a",' +
+        '"title":{"unexpected":true}}\n\n',
+    );
+
+    assertEquals(result.events.flatMap((entry) => entry.chatEvents), [
+      { type: "source-url", sourceId: "web-1", url: "https://example.com/a" },
+    ]);
+  });
+
+  it("renders or falls back on a wrong-typed optional field instead of rejecting the frame", () => {
+    ensureTestSchemaValidator();
+    // The encoder never type-checks title/filename/url before sending them,
+    // so a wrong-typed value (not just null) must not reject the whole
+    // frame either: the legacy `Custom` twin only ever asked
+    // `typeof value.field === "string"` when deciding how to render.
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const frames = [
+      'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown",' +
+      '"title":"Report","filename":42}\n\n',
+      'event: FileAttached\ndata: {"url":"https://cdn.example.com/a.pdf",' +
+      '"mediaType":"application/pdf","filename":42}\n\n',
+    ].join("");
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown", title: "Report" },
+      { type: "file", url: "https://cdn.example.com/a.pdf", mediaType: "application/pdf" },
+    ]);
+  });
+
+  it("strips live encoder timing stamps out of reconstructed legacy data payloads", () => {
+    ensureTestSchemaValidator();
+    // stampAgUiEventTiming (encoder.ts) stamps elapsedMs/emittedAt onto a
+    // native frame's own flat payload once a real clock is configured. A
+    // Custom frame's payload is `{ name, value }`, so the stamp lands beside
+    // `value` and the twin's decoded chunk never carried these two fields --
+    // reusing a native frame's whole payload as legacy `data` must not leak
+    // them in either.
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const frames = [
+      'event: ToolCallStatusChanged\ndata: {"toolCallId":"tool-1","toolCallName":"create_file",' +
+      '"status":"pending_input","elapsedMs":42,"emittedAt":1757400000000}\n\n',
+      'event: ChildRunStatusChanged\ndata: {"toolCallId":"t","childRunId":"r",' +
+      '"status":"running","elapsedMs":42,"emittedAt":1757400000000}\n\n',
+      'event: DocumentCited\ndata: {"sourceId":"doc-1","mediaType":"text/markdown",' +
+      '"elapsedMs":42,"emittedAt":1757400000000}\n\n',
+      'event: FileAttached\ndata: {"mediaType":"application/pdf","elapsedMs":42,' +
+      '"emittedAt":1757400000000}\n\n',
+    ].join("");
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      {
+        type: "data-tool-call-status",
+        data: { toolCallId: "tool-1", toolCallName: "create_file", status: "pending_input" },
+      },
+      {
+        type: "data-veryfront.invoke_agent.lifecycle",
+        data: { toolCallId: "t", childRunId: "r", status: "running" },
+      },
+      {
+        type: "data-source-document",
+        data: { type: "source-document", sourceId: "doc-1", mediaType: "text/markdown" },
+      },
+      {
+        type: "data-file",
+        data: { type: "file", mediaType: "application/pdf" },
+      },
+    ]);
+  });
 });

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -772,8 +772,9 @@ describe("chat/ag-ui", () => {
   it("accepts empty-string title and filename like the legacy custom mapping", () => {
     ensureTestSchemaValidator();
     // The native builders drop an empty title/filename/url before either
-    // wire shape ever carries it (native-run-events.ts's omitEmptyStrings,
-    // I1), so this scenario is unreachable from this producer today -- but a
+    // wire shape ever carries it (native-run-events.ts's
+    // omitInvalidOptionalStrings, I1), so this scenario is unreachable from
+    // this producer today -- but a
     // replayed or hand-built frame could still carry a literal empty string,
     // and the legacy `Custom` twin only ever checked
     // `typeof value.title === "string"`, with no length requirement, so the
@@ -941,10 +942,12 @@ describe("chat/ag-ui", () => {
 
   it("tolerates a null optional field the way the legacy custom mapping did", () => {
     ensureTestSchemaValidator();
-    // `buildNativeRunEventFrame` preserves title/filename/url exactly as it
-    // received them, including an explicit null, and the legacy `Custom`
-    // twin's `typeof value.field === "string"` guard never rejected a null
-    // value outright — it just omitted the field. A renderable citation or
+    // This decoder must tolerate title/filename/url arriving on the wire as
+    // an explicit null, the way a replayed or hand-built frame still could
+    // even though the native builders now drop one (omitInvalidOptionalStrings,
+    // I1), because the legacy `Custom` twin's `typeof value.field === "string"`
+    // guard never rejected a null value outright — it just omitted the
+    // field. A renderable citation or
     // attachment with a null filename must still render, a null title on a
     // DocumentCited falls back to the source id the same way an absent one
     // does, and a null field on an otherwise-unrenderable FileAttached must

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -116,12 +116,19 @@ const AG_UI_WIRE_EVENT_NAMES = [
   "ToolCallChunk",
   "ToolCallEnd",
   "ToolCallResult",
+  "ToolCallStatusChanged",
   "StateSnapshot",
   "MessagesSnapshot",
   "ReasoningMessageStart",
   "ReasoningMessageContent",
   "ReasoningMessageEnd",
   "StateDelta",
+  "InputRequestCreated",
+  "InputRequestUpdated",
+  "ChildRunStatusChanged",
+  "UrlCited",
+  "DocumentCited",
+  "FileAttached",
   "RunFinished",
   "RunError",
 ] as const;
@@ -519,6 +526,67 @@ export const getAgUiWireEventSchema = defineSchema((v) =>
       }),
     }),
     v.object({
+      eventName: v.literal("ToolCallStatusChanged"),
+      payload: v.object({
+        toolCallId: v.string().min(1),
+        status: v.string().min(1),
+        toolCallName: v.string().nullable(),
+      }).passthrough(),
+    }),
+    v.object({
+      eventName: v.literal("InputRequestCreated"),
+      payload: v.object({
+        inputRequest: v.object({ id: v.string().min(1) }).passthrough(),
+      }).passthrough(),
+    }),
+    v.object({
+      eventName: v.literal("InputRequestUpdated"),
+      payload: v.object({
+        inputRequest: v.object({ id: v.string().min(1) }).passthrough(),
+      }).passthrough(),
+    }),
+    v.object({
+      eventName: v.literal("ChildRunStatusChanged"),
+      payload: v.object({
+        toolCallId: v.string().min(1),
+        childRunId: v.string().min(1),
+        status: v.string().min(1),
+      }).passthrough(),
+    }),
+    v.object({
+      eventName: v.literal("UrlCited"),
+      payload: v.object({
+        sourceId: v.string().min(1),
+        url: v.string().min(1),
+      }).passthrough(),
+    }),
+    v.object({
+      eventName: v.literal("DocumentCited"),
+      payload: v.object({
+        sourceId: v.string().min(1),
+        mediaType: v.string().min(1),
+        // The builders pass title/filename through unguarded, so these can
+        // legitimately arrive as anything: an empty string, null, or even a
+        // wrong-typed value the producer never meant to send. The legacy
+        // `Custom` twin never rejected a frame over their type either — it
+        // just checked `typeof value.title === "string"` when deciding
+        // whether to render, and dropped the field otherwise. Constraining
+        // the type here would reject a whole frame the twin would have
+        // rendered (or gracefully fallen back on); the mapping arm below
+        // makes the same typeof decision the twin made.
+        title: v.unknown().optional(),
+        filename: v.unknown().optional(),
+      }).passthrough(),
+    }),
+    v.object({
+      eventName: v.literal("FileAttached"),
+      payload: v.object({
+        mediaType: v.string().min(1),
+        url: v.unknown().optional(),
+        filename: v.unknown().optional(),
+      }).passthrough(),
+    }),
+    v.object({
       eventName: v.literal("RunFinished"),
       payload: v.object({ metadata: getAgUiRunFinishedMetadataSchema().optional() }),
     }),
@@ -617,6 +685,35 @@ function isValidAgUiPayload(
     case "ToolCallEnd":
       return hasStringField(payload, "toolCallId");
 
+    case "ToolCallStatusChanged":
+      // toolCallName is required and nullable in the API variant, so the two
+      // decode paths agree only if this one checks that it is present.
+      return hasStringField(payload, "toolCallId") &&
+        hasStringField(payload, "status") &&
+        (payload.toolCallName === null || typeof payload.toolCallName === "string");
+
+    case "InputRequestCreated":
+    case "InputRequestUpdated":
+      return isRecord(payload.inputRequest) && hasStringField(payload.inputRequest, "id");
+
+    case "ChildRunStatusChanged":
+      return hasStringField(payload, "toolCallId") &&
+        hasStringField(payload, "childRunId") &&
+        hasStringField(payload, "status");
+
+    case "UrlCited":
+      return hasStringField(payload, "sourceId") && hasStringField(payload, "url");
+
+    case "DocumentCited":
+      // title/filename are read but never type-checked here: the mapping
+      // arm decides renderability with the same `typeof value === "string"`
+      // test the legacy `Custom` twin used, so a wrong-typed or absent value
+      // falls back gracefully instead of rejecting the whole frame.
+      return hasStringField(payload, "sourceId") && hasStringField(payload, "mediaType");
+
+    case "FileAttached":
+      return hasStringField(payload, "mediaType");
+
     case "ToolCallResult":
       return hasStringField(payload, "toolCallId") &&
         (payload.messageId === undefined || hasStringField(payload, "messageId")) &&
@@ -712,6 +809,19 @@ function parseAgUiWireEvent(
   }
 
   return parseAgUiWireEventWithoutSchema(frame.event, payload, input.validationMode);
+}
+
+// `stampAgUiEventTiming` (encoder.ts) stamps `elapsedMs`/`emittedAt` onto
+// every event's own flat payload once the encoder has a real clock. A
+// `Custom` frame's payload is `{ name, value }`, so the stamp lands beside
+// `value` and never leaks into it -- the same fix already applied to the
+// durable-record reader (legacy-run-read-adapter.ts). A native frame's
+// payload carries its semantic fields at that same top level, so reusing it
+// wholesale as legacy `data` would leak these two transport fields into a
+// chunk the twin never put them in. Strip them before reuse.
+function stripAgUiTimingStamps(payload: Record<string, unknown>): Record<string, unknown> {
+  const { elapsedMs: _elapsedMs, emittedAt: _emittedAt, ...rest } = payload;
+  return rest;
 }
 
 function mapWireEventToChatEvents(
@@ -873,6 +983,84 @@ function mapWireEventToChatEvents(
       return [{
         type: `data-${wireEvent.payload.name}`,
         data: wireEvent.payload.value,
+      }];
+    }
+
+    case "ToolCallStatusChanged":
+      return [{
+        type: "data-tool-call-status",
+        data: stripAgUiTimingStamps(wireEvent.payload),
+      }];
+
+    case "InputRequestCreated":
+    case "InputRequestUpdated":
+      return [{
+        type: "data-veryfront.input_request.lifecycle",
+        data: {
+          action: wireEvent.eventName === "InputRequestCreated" ? "created" : "updated",
+          inputRequest: wireEvent.payload.inputRequest,
+        },
+      }];
+
+    case "ChildRunStatusChanged":
+      return [{
+        type: "data-veryfront.invoke_agent.lifecycle",
+        data: stripAgUiTimingStamps(wireEvent.payload),
+      }];
+
+    case "UrlCited": {
+      // Only sourceId and url are declared: title is passed through
+      // unvalidated (schema and schemaless paths both leave it unchecked),
+      // so guard its type the way toRenderableCustomChunk does rather than
+      // spreading it straight into the chat event.
+      const { sourceId, url } = wireEvent.payload;
+      const rawTitle = (wireEvent.payload as Record<string, unknown>).title;
+      return [{
+        type: "source-url",
+        sourceId,
+        url,
+        ...(typeof rawTitle === "string" ? { title: rawTitle } : {}),
+      }];
+    }
+
+    case "DocumentCited": {
+      const { sourceId, mediaType, title, filename } = wireEvent.payload;
+      if (typeof title !== "string") {
+        // The encoder's `toFrame` strips the chunk's own `type` before it
+        // goes on the wire (native frames carry it as the AG-UI event name
+        // instead), but the legacy `Custom` twin's `value` never had it
+        // stripped, so its fallback `data` still carried `type:
+        // "source-document"`. Restore it so this fallback is byte-identical
+        // to what the twin produced, and later `type` wins over anything a
+        // crafted payload smuggled in under that key.
+        return [{
+          type: "data-source-document",
+          data: { ...stripAgUiTimingStamps(wireEvent.payload), type: "source-document" },
+        }];
+      }
+      return [{
+        type: "source-document",
+        sourceId,
+        mediaType,
+        title,
+        ...(typeof filename === "string" ? { filename } : {}),
+      }];
+    }
+
+    case "FileAttached": {
+      const { mediaType, url, filename } = wireEvent.payload;
+      if (typeof url !== "string") {
+        // See the matching comment in the DocumentCited fallback above.
+        return [{
+          type: "data-file",
+          data: { ...stripAgUiTimingStamps(wireEvent.payload), type: "file" },
+        }];
+      }
+      return [{
+        type: "file",
+        url,
+        mediaType,
+        ...(typeof filename === "string" ? { filename } : {}),
       }];
     }
 

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -556,8 +556,16 @@ export const getAgUiWireEventSchema = defineSchema((v) =>
     v.object({
       eventName: v.literal("UrlCited"),
       payload: v.object({
-        sourceId: v.string().min(1),
+        // toRenderableCustomChunk falls back to url when sourceId is absent
+        // or empty, so sourceId is optional here too (unreachable from this
+        // producer today -- buildUrlCitedEvent always sets it -- but the
+        // mapping arm still needs to make the same call the twin did for a
+        // replayed or hand-built frame). title is undeclared in the API
+        // catalog and passed through unguarded like its DocumentCited and
+        // FileAttached siblings, so it is unknown here too.
+        sourceId: v.string().optional(),
         url: v.string().min(1),
+        title: v.unknown().optional(),
       }).passthrough(),
     }),
     v.object({
@@ -702,7 +710,10 @@ function isValidAgUiPayload(
         hasStringField(payload, "status");
 
     case "UrlCited":
-      return hasStringField(payload, "sourceId") && hasStringField(payload, "url");
+      // sourceId is optional, like the schema variant: the mapping arm
+      // falls back to url the way toRenderableCustomChunk did, so its type
+      // (when present) is the only thing checked here.
+      return hasOptionalStringField(payload, "sourceId") && hasStringField(payload, "url");
 
     case "DocumentCited":
       // title/filename are read but never type-checked here: the mapping
@@ -1009,17 +1020,18 @@ function mapWireEventToChatEvents(
       }];
 
     case "UrlCited": {
-      // Only sourceId and url are declared: title is passed through
-      // unvalidated (schema and schemaless paths both leave it unchecked),
-      // so guard its type the way toRenderableCustomChunk does rather than
-      // spreading it straight into the chat event.
-      const { sourceId, url } = wireEvent.payload;
-      const rawTitle = (wireEvent.payload as Record<string, unknown>).title;
+      // title is never type-checked by either validator (like its
+      // DocumentCited and FileAttached siblings), so guard it here the way
+      // toRenderableCustomChunk does rather than spreading it straight into
+      // the chat event. sourceId mirrors that same twin: fall back to url
+      // when it is absent or empty instead of requiring it.
+      const { sourceId, url, title } = wireEvent.payload;
+      const resolvedSourceId = typeof sourceId === "string" && sourceId.length > 0 ? sourceId : url;
       return [{
         type: "source-url",
-        sourceId,
+        sourceId: resolvedSourceId,
         url,
-        ...(typeof rawTitle === "string" ? { title: rawTitle } : {}),
+        ...(typeof title === "string" ? { title } : {}),
       }];
     }
 

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -1024,37 +1024,43 @@ function mapWireEventToChatEvents(
       // DocumentCited and FileAttached siblings), so guard it here the way
       // toRenderableCustomChunk does rather than spreading it straight into
       // the chat event. sourceId mirrors that same twin: fall back to url
-      // when it is absent or empty instead of requiring it.
+      // when it is absent or empty instead of requiring it. A wrong-typed
+      // title (present, but not a string) is still dropped rather than
+      // rendered or defaulted, matching toRenderableCustomChunk's own
+      // `typeof value.title === "string"` guard. Only a genuinely absent
+      // title -- the encoder drops an empty one before either shape ever
+      // carries it (I1) -- falls back to the resolved source id, for
+      // consistency with this event's DocumentCited sibling, which needs
+      // the same fallback because its own title is not optional.
       const { sourceId, url, title } = wireEvent.payload;
       const resolvedSourceId = typeof sourceId === "string" && sourceId.length > 0 ? sourceId : url;
+      const resolvedTitle = title === undefined
+        ? resolvedSourceId
+        : typeof title === "string"
+        ? title
+        : undefined;
       return [{
         type: "source-url",
         sourceId: resolvedSourceId,
         url,
-        ...(typeof title === "string" ? { title } : {}),
+        ...(resolvedTitle !== undefined ? { title: resolvedTitle } : {}),
       }];
     }
 
     case "DocumentCited": {
+      // ChatSourceDocumentUiPart.title is a required chat UI field, unlike
+      // UrlCited's title or this event's own filename, so an absent title
+      // (the encoder drops an empty one before either shape carries it, I1)
+      // falls back to the citation's source id rather than making the whole
+      // citation unrenderable: sourceId and mediaType are already validated
+      // strings by the time a payload reaches this arm (isValidAgUiPayload's
+      // DocumentCited case requires both), so this citation always renders.
       const { sourceId, mediaType, title, filename } = wireEvent.payload;
-      if (typeof title !== "string") {
-        // The encoder's `toFrame` strips the chunk's own `type` before it
-        // goes on the wire (native frames carry it as the AG-UI event name
-        // instead), but the legacy `Custom` twin's `value` never had it
-        // stripped, so its fallback `data` still carried `type:
-        // "source-document"`. Restore it so this fallback is byte-identical
-        // to what the twin produced, and later `type` wins over anything a
-        // crafted payload smuggled in under that key.
-        return [{
-          type: "data-source-document",
-          data: { ...stripAgUiTimingStamps(wireEvent.payload), type: "source-document" },
-        }];
-      }
       return [{
         type: "source-document",
         sourceId,
         mediaType,
-        title,
+        title: typeof title === "string" ? title : sourceId,
         ...(typeof filename === "string" ? { filename } : {}),
       }];
     }

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -530,7 +530,7 @@ export const getAgUiWireEventSchema = defineSchema((v) =>
       payload: v.object({
         toolCallId: v.string().min(1),
         status: v.string().min(1),
-        toolCallName: v.string().nullable(),
+        toolCallName: v.string().nullable().optional(),
       }).passthrough(),
     }),
     v.object({
@@ -694,11 +694,11 @@ function isValidAgUiPayload(
       return hasStringField(payload, "toolCallId");
 
     case "ToolCallStatusChanged":
-      // toolCallName is required and nullable in the API variant, so the two
-      // decode paths agree only if this one checks that it is present.
+      // Match the optional, nullable name accepted by the internal SSE formatter.
       return hasStringField(payload, "toolCallId") &&
         hasStringField(payload, "status") &&
-        (payload.toolCallName === null || typeof payload.toolCallName === "string");
+        (payload.toolCallName === undefined || payload.toolCallName === null ||
+          typeof payload.toolCallName === "string");
 
     case "InputRequestCreated":
     case "InputRequestUpdated":

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -1068,7 +1068,17 @@ function mapWireEventToChatEvents(
     case "FileAttached": {
       const { mediaType, url, filename } = wireEvent.payload;
       if (typeof url !== "string") {
-        // See the matching comment in the DocumentCited fallback above.
+        // Unlike DocumentCited's title, url has no safe non-empty fallback
+        // here -- a placeholder would be an actively misleading, possibly
+        // broken link -- so a missing one still falls back to a raw data
+        // chunk instead of rendering, matching what the legacy `Custom`
+        // wrapper's `toRenderableCustomChunk` (ag-ui-helpers.ts) always did
+        // for a `file` value with no url. The encoder's `toFrame` strips the
+        // chunk's own `type` before it goes on the wire (native frames carry
+        // it as the AG-UI event name instead), but the legacy `Custom`
+        // twin's `value` never had it stripped, so its fallback `data` still
+        // carried `type: "file"`. Restore it so this fallback is
+        // byte-identical to what the twin produced.
         return [{
           type: "data-file",
           data: { ...stripAgUiTimingStamps(wireEvent.payload), type: "file" },

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -788,28 +788,22 @@ describe("eval/agent-service", () => {
         createSseResponse([
           { event: "RunStarted", data: { runId: "run_123" } },
           {
-            event: "Custom",
+            event: "ToolCallStatusChanged",
             data: {
-              name: "tool-call-status",
-              value: {
-                toolCallId: "tool_1",
-                toolCallName: "veryfront_agent.github_get_implementation_frontier",
-                status: "in_progress",
-                arguments: {},
-              },
+              toolCallId: "tool_1",
+              toolCallName: "veryfront_agent.github_get_implementation_frontier",
+              status: "in_progress",
+              arguments: {},
             },
           },
           {
-            event: "Custom",
+            event: "ToolCallStatusChanged",
             data: {
-              name: "tool-call-status",
-              value: {
-                toolCallId: "tool_1",
-                toolCallName: "veryfront_agent.github_get_implementation_frontier",
-                status: "completed",
-                arguments: {},
-                result: { nextAction: { kind: "agent-brief-repair" } },
-              },
+              toolCallId: "tool_1",
+              toolCallName: "veryfront_agent.github_get_implementation_frontier",
+              status: "completed",
+              arguments: {},
+              result: { nextAction: { kind: "agent-brief-repair" } },
             },
           },
           { event: "TextMessageContent", data: { delta: '{"nextAction":{}}' } },
@@ -871,16 +865,13 @@ describe("eval/agent-service", () => {
         createSseResponse([
           { event: "RunStarted", data: { runId: "run_123" } },
           {
-            event: "Custom",
+            event: "ToolCallStatusChanged",
             data: {
-              name: "tool-call-status",
-              value: {
-                toolCallId: "tool_1",
-                toolCallName: "veryfront_agent.github_update_issue",
-                status: "failed",
-                arguments: { issue_number: 27 },
-                error: { message: "write denied" },
-              },
+              toolCallId: "tool_1",
+              toolCallName: "veryfront_agent.github_update_issue",
+              status: "failed",
+              arguments: { issue_number: 27 },
+              error: { message: "write denied" },
             },
           },
           { event: "RunFinished", data: {} },
@@ -908,7 +899,10 @@ describe("eval/agent-service", () => {
     assertEquals(record.metrics?.[0]?.pass, false);
   });
 
-  it("keeps standard AG-UI tool results authoritative in mixed hosted streams", async () => {
+  it("still recognizes a legacy CUSTOM tool-call-status frame with no toolCallId", async () => {
+    // The live encoder falls back to the legacy CUSTOM shape when it cannot
+    // build a native TOOL_CALL_STATUS_CHANGED frame (buildNativeRunEventFrame
+    // requires a toolCallId), so a name-only status must still be read.
     const adapter = createAgentServiceEvalAdapter({
       endpoint: "http://127.0.0.1:4311/api/ag-ui",
       authToken: "token",
@@ -920,12 +914,44 @@ describe("eval/agent-service", () => {
             data: {
               name: "tool-call-status",
               value: {
-                toolCallId: "tool_1",
-                toolCallName: "search",
+                toolCallName: "write",
                 status: "failed",
-                result: { source: "custom" },
-                error: { message: "custom failure" },
+                error: { message: "write denied" },
               },
+            },
+          },
+          { event: "RunFinished", data: {} },
+        ]),
+    });
+    const definition = evalAgent({
+      id: "eval:legacy-name-only-tool-status",
+      target: "agent:veryfront",
+      dataset: datasets.inline([{ id: "mutation", input: "Write a file" }]),
+      metrics: [metrics.agent.noFailedTools()],
+    });
+
+    const report = await runEval(definition, {
+      adapters: { agent: adapter },
+    });
+
+    assertEquals(report.records[0]?.metrics?.[0]?.pass, false);
+  });
+
+  it("keeps standard AG-UI tool results authoritative in mixed hosted streams", async () => {
+    const adapter = createAgentServiceEvalAdapter({
+      endpoint: "http://127.0.0.1:4311/api/ag-ui",
+      authToken: "token",
+      fetch: async () =>
+        createSseResponse([
+          { event: "RunStarted", data: { runId: "run_123" } },
+          {
+            event: "ToolCallStatusChanged",
+            data: {
+              toolCallId: "tool_1",
+              toolCallName: "search",
+              status: "failed",
+              result: { source: "custom" },
+              error: { message: "custom failure" },
             },
           },
           {
@@ -946,15 +972,12 @@ describe("eval/agent-service", () => {
             },
           },
           {
-            event: "Custom",
+            event: "ToolCallStatusChanged",
             data: {
-              name: "tool-call-status",
-              value: {
-                toolCallId: "tool_2",
-                toolCallName: "write",
-                status: "completed",
-                result: { source: "custom" },
-              },
+              toolCallId: "tool_2",
+              toolCallName: "write",
+              status: "completed",
+              result: { source: "custom" },
             },
           },
           { event: "RunFinished", data: {} },

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -384,15 +384,21 @@ function applyToolCallStatusEvent(
   event: Record<string, unknown>,
   index: number,
 ): boolean {
-  if (
-    getAgUiSseStringField(event, "type") !== agUiSseEventTypes.custom ||
-    getAgUiSseStringField(event, "name") !== "tool-call-status" ||
-    !isRecord(event.value)
-  ) {
+  const isNative = getAgUiSseStringField(event, "type") === agUiSseEventTypes.toolCallStatusChanged;
+  const isLegacyCustom = !isNative &&
+    getAgUiSseStringField(event, "type") === agUiSseEventTypes.custom &&
+    getAgUiSseStringField(event, "name") === "tool-call-status" &&
+    isRecord(event.value);
+  if (!isNative && !isLegacyCustom) {
     return false;
   }
 
-  const value = event.value;
+  // The native payload is the value itself: TOOL_CALL_STATUS_CHANGED replaced
+  // the Custom wrapper that used to nest it under `value`. The legacy CUSTOM
+  // shape stays reachable when the native builder rejects an incomplete
+  // payload (for example, a status update with no toolCallId), so both are
+  // read here.
+  const value = isNative ? event : (event.value as Record<string, unknown>);
   const id = getAgUiSseStringField(value, "toolCallId");
   const name = getAgUiSseStringField(value, "toolCallName");
   if (!id && !name) return true;

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -77,7 +77,11 @@ describe("internal-agents/ag-ui-sse", () => {
         },
         {
           event: "ToolCallStart",
-          payload: { toolCallId: "tool-1", toolCallName: "studio_focus_component" },
+          payload: {
+            toolCallId: "tool-1",
+            toolCallName: "studio_focus_component",
+            parentMessageId: "assistant-1",
+          },
         },
       ],
     );
@@ -598,6 +602,7 @@ describe("internal-agents/ag-ui-sse", () => {
         payload: {
           toolCallId: CANONICAL_TOOL_CALL_ID,
           toolCallName: CANONICAL_TOOL_NAME,
+          parentMessageId: "assistant-msg-1",
         },
       },
       {

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -413,6 +413,31 @@ describe("internal-agents/ag-ui-sse", () => {
     );
   });
 
+  it("does not throw when a ToolCallStatusChanged frame omits toolCallName", () => {
+    // N2: the API catalog declares toolCallName a required `nullableString`,
+    // and buildToolCallStatusChangedEvent always writes it as a string or
+    // null today, so a frame missing it entirely is unreachable from this
+    // producer. But this allow-list's job is to validate, not to newly
+    // reject what the unvalidated pass-through it replaces never rejected
+    // either -- a required-key throw here is uncaught by some callers and
+    // aborts the whole run stream over one missing field, worse than the
+    // dropped-field failure mode this file exists to prevent. Optional
+    // keeps a frame without it reaching the wire instead.
+    const payload = new TextDecoder().decode(
+      formatAgUiEvent("ToolCallStatusChanged", {
+        toolCallId: "tool-1",
+        status: "completed",
+        emittedAt: 8,
+      }),
+    );
+
+    assertEquals(
+      payload,
+      'event: ToolCallStatusChanged\ndata: {"toolCallId":"tool-1","status":"completed",' +
+        '"emittedAt":8}\n\n',
+    );
+  });
+
   it("carries elapsedMs through to the wire without widening the allow-list", () => {
     // These payload schemas are an allow-list and `parse` returns only what
     // they declare, so a stamped field missing from a schema is dropped

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -388,6 +388,31 @@ describe("internal-agents/ag-ui-sse", () => {
     );
   });
 
+  it("declares the seven native run event names in the payload allow-list with extra fields intact", () => {
+    // M3: the seven native wire names used to have no schema entry, so they
+    // took formatAgUiEvent's unvalidated pass-through branch instead of this
+    // allow-list. Nothing was dropped by that, but the next person to add a
+    // partial schema entry for one of them would reintroduce the elapsedMs
+    // bug this file's allow-list exists to prevent. Each entry is
+    // `.passthrough()`-ed, so an extension field a builder attaches (like
+    // ToolCallStatusChanged's `result`) must still reach the wire.
+    const payload = new TextDecoder().decode(
+      formatAgUiEvent("ToolCallStatusChanged", {
+        toolCallId: "tool-1",
+        status: "completed",
+        toolCallName: "web_search",
+        result: { ok: true },
+        emittedAt: 8,
+      }),
+    );
+
+    assertEquals(
+      payload,
+      'event: ToolCallStatusChanged\ndata: {"toolCallId":"tool-1","status":"completed",' +
+        '"toolCallName":"web_search","emittedAt":8,"result":{"ok":true}}\n\n',
+    );
+  });
+
   it("carries elapsedMs through to the wire without widening the allow-list", () => {
     // These payload schemas are an allow-list and `parse` returns only what
     // they declare, so a stamped field missing from a schema is dropped

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -84,7 +84,11 @@ function buildAgUiEventPayloadSchemas(): Record<string, Schema<Record<string, un
     ReasoningMessageEnd: withTiming({ messageId: v.string().min(1) }),
     StepStarted: withTiming({ stepName: v.string().min(1) }),
     StepFinished: withTiming({ stepName: v.string().min(1) }),
-    ToolCallStart: withTiming({ toolCallId: v.string().min(1), toolCallName: v.string().min(1) }),
+    ToolCallStart: withTiming({
+      toolCallId: v.string().min(1),
+      toolCallName: v.string().min(1),
+      parentMessageId: v.string().min(1).optional(),
+    }),
     ToolCallArgs: withTiming({ toolCallId: v.string().min(1), delta: v.string() }),
     ToolCallEnd: withTiming({ toolCallId: v.string().min(1) }),
     ToolCallResult: withTiming({

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -136,7 +136,14 @@ function buildAgUiEventPayloadSchemas(): Record<string, Schema<Record<string, un
     ToolCallStatusChanged: withTiming({
       toolCallId: v.string().min(1),
       status: v.string().min(1),
-      toolCallName: v.string().nullable(),
+      // Optional despite the API catalog declaring it a required
+      // `nullableString`: buildToolCallStatusChangedEvent always writes it
+      // as a string or null today, but this allow-list must not throw (and
+      // abort the run stream) on a frame that omits it -- an uncaught throw
+      // here is worse than a field the API rejects downstream, since the
+      // unvalidated pass-through this entry replaces never rejected a
+      // missing field either.
+      toolCallName: v.string().nullable().optional(),
     }).passthrough(),
     InputRequestCreated: withTiming({
       inputRequest: v.object({ id: v.string().min(1) }).passthrough(),

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -126,6 +126,49 @@ function buildAgUiEventPayloadSchemas(): Record<string, Schema<Record<string, un
         finishReason: v.string().optional(),
       }),
     }),
+    // The seven native run event wire names replace the AG-UI `Custom`
+    // wrapper (see native-run-events.ts). They carry API-catalog-required
+    // fields beyond `type` and mirror the shapes declared in
+    // src/chat/ag-ui.ts's decoder schema, each `.passthrough()`-ed so the
+    // extension fields I1 and answer A depend on (result, error, exitCode,
+    // parentMessageId, ...) survive this allow-list rather than being
+    // silently dropped the way elapsedMs once was.
+    ToolCallStatusChanged: withTiming({
+      toolCallId: v.string().min(1),
+      status: v.string().min(1),
+      toolCallName: v.string().nullable(),
+    }).passthrough(),
+    InputRequestCreated: withTiming({
+      inputRequest: v.object({ id: v.string().min(1) }).passthrough(),
+    }).passthrough(),
+    InputRequestUpdated: withTiming({
+      inputRequest: v.object({ id: v.string().min(1) }).passthrough(),
+    }).passthrough(),
+    ChildRunStatusChanged: withTiming({
+      toolCallId: v.string().min(1),
+      childRunId: v.string().min(1),
+      status: v.string().min(1),
+    }).passthrough(),
+    UrlCited: withTiming({
+      // sourceId is optional here for the same reason it is in the chat
+      // decoder: toRenderableCustomChunk falls back to url when it is absent
+      // or empty. title is undeclared in the API catalog and passed through
+      // unguarded like its DocumentCited and FileAttached siblings.
+      sourceId: v.string().optional(),
+      url: v.string().min(1),
+      title: v.unknown().optional(),
+    }).passthrough(),
+    DocumentCited: withTiming({
+      sourceId: v.string().min(1),
+      mediaType: v.string().min(1),
+      title: v.unknown().optional(),
+      filename: v.unknown().optional(),
+    }).passthrough(),
+    FileAttached: withTiming({
+      mediaType: v.string().min(1),
+      url: v.unknown().optional(),
+      filename: v.unknown().optional(),
+    }).passthrough(),
   };
   return schemas;
 }
@@ -159,7 +202,14 @@ type AgUiEventName =
   | "ToolCallResult"
   | "Custom"
   | "RunError"
-  | "RunFinished";
+  | "RunFinished"
+  | "ToolCallStatusChanged"
+  | "InputRequestCreated"
+  | "InputRequestUpdated"
+  | "ChildRunStatusChanged"
+  | "UrlCited"
+  | "DocumentCited"
+  | "FileAttached";
 
 export function formatAgUiEvent(event: string, payload: Record<string, unknown>): Uint8Array {
   const eventNameMatch = AG_UI_EVENT_NAME_PATTERN.exec(event);

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -328,16 +328,16 @@ describe("provider/runtime-loader", () => {
       { type: "tool-input-start", id: "tool-1", toolName: "create_file" },
       {
         type: "data-tool-call-status",
-        data: { toolCallId: "tool-1", status: "pending_input" },
+        data: { toolCallId: "tool-1", toolCallName: "create_file", status: "pending_input" },
       },
       {
         type: "data-tool-call-status",
-        data: { toolCallId: "tool-1", status: "streaming_input" },
+        data: { toolCallId: "tool-1", toolCallName: "create_file", status: "streaming_input" },
       },
       { type: "tool-input-delta", id: "tool-1", delta: '{"path":"docs/report.md"' },
       {
         type: "data-tool-call-status",
-        data: { toolCallId: "tool-1", status: "pending_input" },
+        data: { toolCallId: "tool-1", toolCallName: "create_file", status: "pending_input" },
       },
       {
         type: "tool-call",
@@ -424,7 +424,7 @@ describe("provider/runtime-loader", () => {
     assertEquals(events[0], { type: "tool-input-start", id: "tool-1", toolName: "create_file" });
     assertEquals(events[1], {
       type: "data-tool-call-status",
-      data: { toolCallId: "tool-1", status: "streaming_input" },
+      data: { toolCallId: "tool-1", toolCallName: "create_file", status: "streaming_input" },
     });
     assertEquals(events[firstDeltaIndex], {
       type: "tool-input-delta",
@@ -433,7 +433,7 @@ describe("provider/runtime-loader", () => {
     });
     assertEquals(events[secondDeltaIndex - 1], {
       type: "data-tool-call-status",
-      data: { toolCallId: "tool-1", status: "streaming_input" },
+      data: { toolCallId: "tool-1", toolCallName: "create_file", status: "streaming_input" },
     });
     assertEquals(events[secondDeltaIndex], {
       type: "tool-input-delta",

--- a/src/provider/runtime-loader/tool-input-status.ts
+++ b/src/provider/runtime-loader/tool-input-status.ts
@@ -8,11 +8,16 @@ type ToolInputActivityStatus = "pending_input" | "streaming_input";
 type ToolInputStatusState = {
   dueAt: number | null;
   lastStatus: ToolInputActivityStatus | null;
+  toolCallName: string | null;
 };
 
 type ToolStatusEvent = {
   type: "data-tool-call-status";
-  data: { toolCallId: string; status: "pending_input" | "streaming_input" };
+  data: {
+    toolCallId: string;
+    toolCallName: string | null;
+    status: "pending_input" | "streaming_input";
+  };
 };
 
 type ToolInputStatusLifecycle = {
@@ -40,13 +45,35 @@ export function getToolCallIdFromStreamPart(part: unknown): string | null {
   return null;
 }
 
+/** Return the tool name a provider stream part carries, when it names one. */
+export function getToolNameFromStreamPart(part: unknown): string | null {
+  if (!part || typeof part !== "object") {
+    return null;
+  }
+
+  const record = part as Record<string, unknown>;
+  if (typeof record.toolName === "string" && record.toolName.length > 0) {
+    return record.toolName;
+  }
+
+  return null;
+}
+
 export function collectDueToolStatuses(
   toolStates: Map<string, ToolInputStatusState>,
   now: number,
   thresholdMs: number,
-): Array<{ type: "data-tool-call-status"; data: { toolCallId: string; status: "pending_input" } }> {
+): Array<
+  {
+    type: "data-tool-call-status";
+    data: { toolCallId: string; toolCallName: string | null; status: "pending_input" };
+  }
+> {
   const events: Array<
-    { type: "data-tool-call-status"; data: { toolCallId: string; status: "pending_input" } }
+    {
+      type: "data-tool-call-status";
+      data: { toolCallId: string; toolCallName: string | null; status: "pending_input" };
+    }
   > = [];
 
   for (const [toolCallId, state] of toolStates.entries()) {
@@ -60,6 +87,7 @@ export function collectDueToolStatuses(
       type: "data-tool-call-status",
       data: {
         toolCallId,
+        toolCallName: state.toolCallName,
         status: "pending_input",
       },
     });
@@ -188,7 +216,7 @@ async function* applyToolInputStatusTransitions(
     toolStates.delete(toolCallId);
   };
 
-  const schedulePending = (toolCallId: string | null) => {
+  const schedulePending = (toolCallId: string | null, toolCallName: string | null) => {
     if (!toolCallId) {
       return;
     }
@@ -196,12 +224,14 @@ async function* applyToolInputStatusTransitions(
     const state = toolStates.get(toolCallId) ?? {
       dueAt: null,
       lastStatus: null,
+      toolCallName: null,
     };
     state.dueAt = Date.now() + thresholdMs;
+    if (toolCallName) state.toolCallName = toolCallName;
     toolStates.set(toolCallId, state);
   };
 
-  const markStreaming = (toolCallId: string | null) => {
+  const markStreaming = (toolCallId: string | null, toolCallName: string | null) => {
     if (!toolCallId) {
       return;
     }
@@ -209,7 +239,9 @@ async function* applyToolInputStatusTransitions(
     const state = toolStates.get(toolCallId) ?? {
       dueAt: null,
       lastStatus: null,
+      toolCallName: null,
     };
+    if (toolCallName) state.toolCallName = toolCallName;
 
     if (state.lastStatus !== "streaming_input") {
       buffered.push(
@@ -217,6 +249,7 @@ async function* applyToolInputStatusTransitions(
           type: "data-tool-call-status",
           data: {
             toolCallId,
+            toolCallName: state.toolCallName,
             status: "streaming_input",
           },
         } satisfies ToolStatusEvent,
@@ -240,11 +273,11 @@ async function* applyToolInputStatusTransitions(
 
     switch (partType) {
       case "tool-input-start":
-        schedulePending(toolCallId);
+        schedulePending(toolCallId, getToolNameFromStreamPart(part));
         buffered.push(part);
         return;
       case "tool-input-delta":
-        markStreaming(toolCallId);
+        markStreaming(toolCallId, getToolNameFromStreamPart(part));
         buffered.push(part);
         return;
       case "tool-call":

--- a/tests/fixtures/contracts/native-run-events.json
+++ b/tests/fixtures/contracts/native-run-events.json
@@ -1,0 +1,216 @@
+[
+  {
+    "storedType": "TOOL_CALL_STATUS_CHANGED",
+    "legacyCustomName": "tool-call-status",
+    "live": {
+      "event": "ToolCallStatusChanged",
+      "payload": {
+        "toolCallId": "toolu_01",
+        "status": "pending_input",
+        "toolCallName": "create_file",
+        "parentMessageId": "33333333-3333-4333-a333-333333333333"
+      }
+    },
+    "durable": {
+      "toolCallId": "toolu_01",
+      "status": "pending_input",
+      "toolCallName": "create_file",
+      "parentMessageId": "33333333-3333-4333-a333-333333333333",
+      "type": "TOOL_CALL_STATUS_CHANGED"
+    }
+  },
+  {
+    "storedType": "INPUT_REQUEST_CREATED",
+    "legacyCustomName": "veryfront.input_request.lifecycle",
+    "live": {
+      "event": "InputRequestCreated",
+      "payload": {
+        "inputRequest": {
+          "id": "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f",
+          "conversationId": "a7c53a3d-feb2-4404-86e2-5c562455e46c",
+          "runId": "run_native_events_1",
+          "toolCallId": "toolu_form_1",
+          "kind": "form",
+          "status": "open",
+          "requestedResponderType": "human",
+          "title": "Choose a deployment target",
+          "description": null,
+          "fields": [{ "type": "confirm", "name": "confirmed", "label": "Confirm?" }],
+          "recommendations": null,
+          "metadata": null,
+          "createdAt": "2026-09-09T00:00:00.000Z",
+          "expiresAt": "2026-09-09T00:15:00.000Z",
+          "submittedAt": null,
+          "cancelledAt": null,
+          "expiredAt": null,
+          "latestResponse": null
+        }
+      }
+    },
+    "durable": {
+      "inputRequest": {
+        "id": "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f",
+        "conversationId": "a7c53a3d-feb2-4404-86e2-5c562455e46c",
+        "runId": "run_native_events_1",
+        "toolCallId": "toolu_form_1",
+        "kind": "form",
+        "status": "open",
+        "requestedResponderType": "human",
+        "title": "Choose a deployment target",
+        "description": null,
+        "fields": [{ "type": "confirm", "name": "confirmed", "label": "Confirm?" }],
+        "recommendations": null,
+        "metadata": null,
+        "createdAt": "2026-09-09T00:00:00.000Z",
+        "expiresAt": "2026-09-09T00:15:00.000Z",
+        "submittedAt": null,
+        "cancelledAt": null,
+        "expiredAt": null,
+        "latestResponse": null
+      },
+      "type": "INPUT_REQUEST_CREATED"
+    }
+  },
+  {
+    "storedType": "INPUT_REQUEST_UPDATED",
+    "legacyCustomName": "veryfront.input_request.lifecycle",
+    "live": {
+      "event": "InputRequestUpdated",
+      "payload": {
+        "inputRequest": {
+          "id": "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f",
+          "conversationId": "a7c53a3d-feb2-4404-86e2-5c562455e46c",
+          "runId": "run_native_events_1",
+          "toolCallId": "toolu_form_1",
+          "kind": "form",
+          "status": "submitted",
+          "requestedResponderType": "human",
+          "title": "Choose a deployment target",
+          "description": null,
+          "fields": [{ "type": "confirm", "name": "confirmed", "label": "Confirm?" }],
+          "recommendations": null,
+          "metadata": null,
+          "createdAt": "2026-09-09T00:00:00.000Z",
+          "expiresAt": "2026-09-09T00:15:00.000Z",
+          "submittedAt": "2026-09-09T00:05:00.000Z",
+          "cancelledAt": null,
+          "expiredAt": null,
+          "latestResponse": null
+        }
+      }
+    },
+    "durable": {
+      "inputRequest": {
+        "id": "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f",
+        "conversationId": "a7c53a3d-feb2-4404-86e2-5c562455e46c",
+        "runId": "run_native_events_1",
+        "toolCallId": "toolu_form_1",
+        "kind": "form",
+        "status": "submitted",
+        "requestedResponderType": "human",
+        "title": "Choose a deployment target",
+        "description": null,
+        "fields": [{ "type": "confirm", "name": "confirmed", "label": "Confirm?" }],
+        "recommendations": null,
+        "metadata": null,
+        "createdAt": "2026-09-09T00:00:00.000Z",
+        "expiresAt": "2026-09-09T00:15:00.000Z",
+        "submittedAt": "2026-09-09T00:05:00.000Z",
+        "cancelledAt": null,
+        "expiredAt": null,
+        "latestResponse": null
+      },
+      "type": "INPUT_REQUEST_UPDATED"
+    }
+  },
+  {
+    "storedType": "CHILD_RUN_STATUS_CHANGED",
+    "legacyCustomName": "veryfront.invoke_agent.lifecycle",
+    "live": {
+      "event": "ChildRunStatusChanged",
+      "payload": {
+        "toolCallId": "toolu_child_1",
+        "childConversationId": "22222222-2222-4222-a222-222222222222",
+        "childRunId": "run_child_1",
+        "childMessageId": "33333333-3333-4333-a333-333333333333",
+        "childAgentId": "researcher",
+        "description": "Inspect logs",
+        "status": "running",
+        "sourceTargetKind": "project",
+        "runtimeTargetKind": "main_branch",
+        "targetEnvironmentId": null,
+        "targetBranchId": null
+      }
+    },
+    "durable": {
+      "toolCallId": "toolu_child_1",
+      "childConversationId": "22222222-2222-4222-a222-222222222222",
+      "childRunId": "run_child_1",
+      "childMessageId": "33333333-3333-4333-a333-333333333333",
+      "childAgentId": "researcher",
+      "description": "Inspect logs",
+      "status": "running",
+      "sourceTargetKind": "project",
+      "runtimeTargetKind": "main_branch",
+      "targetEnvironmentId": null,
+      "targetBranchId": null,
+      "type": "CHILD_RUN_STATUS_CHANGED"
+    }
+  },
+  {
+    "storedType": "URL_CITED",
+    "legacyCustomName": "source-url",
+    "live": {
+      "event": "UrlCited",
+      "payload": {
+        "sourceId": "web-1",
+        "url": "https://example.com/reference",
+        "title": "Reference"
+      }
+    },
+    "durable": {
+      "sourceId": "web-1",
+      "url": "https://example.com/reference",
+      "title": "Reference",
+      "type": "URL_CITED"
+    }
+  },
+  {
+    "storedType": "DOCUMENT_CITED",
+    "legacyCustomName": "source-document",
+    "live": {
+      "event": "DocumentCited",
+      "payload": {
+        "sourceId": "knowledge/report.md",
+        "mediaType": "text/markdown",
+        "title": "Report",
+        "filename": "knowledge/report.md"
+      }
+    },
+    "durable": {
+      "sourceId": "knowledge/report.md",
+      "mediaType": "text/markdown",
+      "title": "Report",
+      "filename": "knowledge/report.md",
+      "type": "DOCUMENT_CITED"
+    }
+  },
+  {
+    "storedType": "FILE_ATTACHED",
+    "legacyCustomName": "file",
+    "live": {
+      "event": "FileAttached",
+      "payload": {
+        "url": "https://cdn.example.com/report.pdf",
+        "mediaType": "application/pdf",
+        "filename": "report.pdf"
+      }
+    },
+    "durable": {
+      "url": "https://cdn.example.com/report.pdf",
+      "mediaType": "application/pdf",
+      "filename": "report.pdf",
+      "type": "FILE_ATTACHED"
+    }
+  }
+]

--- a/tests/integration/semantic-unit-boundary/src/agent/ag-ui/native-run-events-contract.test.ts
+++ b/tests/integration/semantic-unit-boundary/src/agent/ag-ui/native-run-events-contract.test.ts
@@ -1,0 +1,138 @@
+// This test reads the pinned cross-repository contract fixture off disk to
+// hash its bytes, a genuine filesystem read, so it lives in the semantic
+// integration suite rather than beside the colocated unit tests.
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildChildRunStatusChangedEvent,
+  buildDocumentCitedEvent,
+  buildFileAttachedEvent,
+  buildInputRequestLifecycleEvent,
+  buildToolCallStatusChangedEvent,
+  buildUrlCitedEvent,
+  NATIVE_RUN_EVENTS,
+  type NativeRunEventFrame,
+} from "../../../../../../src/agent/ag-ui/native-run-events.ts";
+
+// Resolved from this module's URL, not the working directory, so the suite runs
+// the same way from any cwd.
+const FIXTURE_URL = new URL(
+  "../../../../../../tests/fixtures/contracts/native-run-events.json",
+  import.meta.url,
+);
+
+// The veryfront-api copy of this file pins the same digest, which is what makes
+// the two repositories byte-identical rather than merely similar.
+const NATIVE_RUN_EVENTS_FIXTURE_SHA256 =
+  "a4e3e51168fd6d51d47b5baeb0579be892d4189c9f1231f34853b99744e41287";
+
+const INPUT_REQUEST = {
+  id: "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f",
+  conversationId: "a7c53a3d-feb2-4404-86e2-5c562455e46c",
+  runId: "run_native_events_1",
+  toolCallId: "toolu_form_1",
+  kind: "form",
+  status: "open",
+  requestedResponderType: "human",
+  title: "Choose a deployment target",
+  description: null,
+  fields: [{ type: "confirm", name: "confirmed", label: "Confirm?" }],
+  recommendations: null,
+  metadata: null,
+  createdAt: "2026-09-09T00:00:00.000Z",
+  expiresAt: "2026-09-09T00:15:00.000Z",
+  submittedAt: null,
+  cancelledAt: null,
+  expiredAt: null,
+  latestResponse: null,
+};
+
+function buildSamples(): NativeRunEventFrame[] {
+  return [
+    buildToolCallStatusChangedEvent({
+      toolCallId: "toolu_01",
+      status: "pending_input",
+      toolCallName: "create_file",
+      parentMessageId: "33333333-3333-4333-a333-333333333333",
+    }),
+    buildInputRequestLifecycleEvent({ action: "created", inputRequest: INPUT_REQUEST }),
+    buildInputRequestLifecycleEvent({
+      action: "updated",
+      inputRequest: {
+        ...INPUT_REQUEST,
+        status: "submitted",
+        submittedAt: "2026-09-09T00:05:00.000Z",
+      },
+    }),
+    buildChildRunStatusChangedEvent({
+      toolCallId: "toolu_child_1",
+      childConversationId: "22222222-2222-4222-a222-222222222222",
+      childRunId: "run_child_1",
+      childMessageId: "33333333-3333-4333-a333-333333333333",
+      childAgentId: "researcher",
+      description: "Inspect logs",
+      status: "running",
+      sourceTargetKind: "project",
+      runtimeTargetKind: "main_branch",
+      targetEnvironmentId: null,
+      targetBranchId: null,
+    }),
+    buildUrlCitedEvent({
+      type: "source-url",
+      sourceId: "web-1",
+      url: "https://example.com/reference",
+      title: "Reference",
+    }),
+    buildDocumentCitedEvent({
+      type: "source-document",
+      sourceId: "knowledge/report.md",
+      mediaType: "text/markdown",
+      title: "Report",
+      filename: "knowledge/report.md",
+    }),
+    buildFileAttachedEvent({
+      type: "file",
+      url: "https://cdn.example.com/report.pdf",
+      mediaType: "application/pdf",
+      filename: "report.pdf",
+    }),
+  ];
+}
+
+describe("agent/ag-ui-native-run-events-contract", () => {
+  it("pins one sample per native type in both emission shapes", () => {
+    const fixture = JSON.parse(Deno.readTextFileSync(FIXTURE_URL)) as Array<{
+      storedType: string;
+      legacyCustomName: string;
+      live: { event: string; payload: Record<string, unknown> };
+      durable: Record<string, unknown>;
+    }>;
+
+    assertEquals(fixture.length, NATIVE_RUN_EVENTS.length);
+    assertEquals(
+      fixture.map((entry) => [entry.storedType, entry.legacyCustomName]),
+      NATIVE_RUN_EVENTS.map((entry) => [entry.storedType, entry.legacyCustomName]),
+    );
+    assertEquals(
+      buildSamples().map((frame) => ({ live: frame.live, durable: frame.durable })),
+      fixture.map((entry) => ({ live: entry.live, durable: entry.durable })),
+      "regenerate tests/fixtures/contracts/native-run-events.json and the veryfront-api copy",
+    );
+  });
+
+  it("keeps the durable shape a restatement of the live payload", () => {
+    for (const frame of buildSamples()) {
+      assertEquals(frame.durable, { ...frame.live.payload, type: frame.durable.type });
+    }
+  });
+
+  it("matches the digest the veryfront-api copy pins", async () => {
+    const bytes = Deno.readFileSync(FIXTURE_URL);
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    assertEquals(
+      [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join(""),
+      NATIVE_RUN_EVENTS_FIXTURE_SHA256,
+    );
+  });
+});


### PR DESCRIPTION
Veryfront now emits native run events for tool status, input requests, child-run status, citations, and attachments across live SSE and durable publication. A shared vocabulary produces both shapes, and the readers continue to accept legacy Custom events.

The public child-run Custom-event builders, schemas, types, and publisher callbacks retain their existing contract. Native conversion happens at the shared direct-append and mirror publication boundary. Both chat decoder validation paths accept omitted, null, or string tool names from the internal SSE formatter, in strict and permissive modes. Reserved `type`, `elapsedMs`, and `emittedAt` fields are removed before application values become native payloads. Input records cannot override the native wire type or transport clocks; nested application metadata remains intact.

The scope spans producers, transport, persistence, replay, chat decoding, and evaluation because each must agree on the event shapes. The shared contract fixture and reader round trips cover those boundaries. The browser vocabulary stays separate to preserve client bundle boundaries, with tests that check it against the producer vocabulary.

Oversized tool-status, input-request, and child-run records produce bounded omission markers that retain the original event type and tool call ID where available. Dedicated tests cover all four stored lifecycle types. Full payload retention for those oversized records remains outside this change.

Deployment requires API support for these native events before the runtime ships. Staging validation of a slow tool call, citation, and child run remains outstanding. The runtime-context Custom event is unchanged and outside this PR.

Validation uses the pinned Deno 2.7.7. Focused regressions reproduce the public API, native-type, and optional tool-name failures before their fixes. The final broader event and consumer suite passes: 93 tests and 1,173 steps. The latest timing regressions and encoder cases pass: 5 tests and 90 steps. Twenty timestamp-collision cases failed before their fix. Types, lint, formatting, client-bundle boundaries, test audits, generated references, and diff checks pass. The [CI/CD workflow](https://github.com/veryfront/veryfront-code/actions/runs/34445048454) and [Codex review](https://github.com/veryfront/veryfront-code/pull/4467#issuecomment-5614197778) pass for `4d21b9d7901e45b4fab34073e416d5f5c45fcd02`. All review threads are resolved, and the PR is conflict-free and ready for review.
