### PR TITLE
fix(mcp): preserve platform selectors across namespace rollout

### DIFF
--- a/docs/architecture/21-agent-tool-registration-current-state.md
+++ b/docs/architecture/21-agent-tool-registration-current-state.md
@@ -73,6 +73,14 @@ The hosted path starts from `mcpServers`, converts each server config into a
 project-aware behavior, and finally maps it back into `AgentConfig.remoteTools`.
 Local host tools are converted separately into `runtimeTools`.
 
+Veryfront API sources request `_meta["veryfront/tool-names"] = "legacy"` on every
+`tools/list` page. This keeps persisted selectors, allow/deny rules, hosted access
+profiles, and streamed tool names stable when the API advertises canonical
+`veryfront__` names. Older APIs may ignore this additive metadata and continue
+returning legacy names. Generic and Studio sources retain their existing discovery
+requests. Discovery metadata is not added to `tools/call`; calls use the exact
+selected tool identity.
+
 ## Current configuration surfaces
 
 ### AgentConfig

--- a/src/agent/service/mcp-server-config.test.ts
+++ b/src/agent/service/mcp-server-config.test.ts
@@ -1,8 +1,4 @@
-import "#veryfront/schemas/_test-setup.ts";
-import { createRemoteMCPToolSource } from "#veryfront/tool";
-import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
-import { wrapRemoteToolSourceWithMcpPolicy } from "../mcp-tool-policy.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   createAgentServiceRemoteMcpConfig,
@@ -23,6 +19,7 @@ it("createAgentServiceRemoteMcpConfig builds Veryfront API MCP config", async ()
     getProjectId: () => projectId,
   });
   assertEquals(config?.id, "veryfront-mcp");
+  assertEquals(config?.listMeta, { "veryfront/tool-names": "legacy" });
   assertEquals(
     typeof config?.endpoint === "function" ? await config.endpoint() : config?.endpoint,
     "https://api.example/projects/project-1/mcp",
@@ -153,55 +150,4 @@ it("createAgentServiceRemoteMcpConfig gates Studio MCP by client profile", async
     "x-conversation-id": "conversation-1",
     "x-project-id": "project-2",
   });
-});
-
-it("keeps legacy invocation and deny policies across API naming versions", async () => {
-  for (const supportsNamingMode of [true, false]) {
-    const config = createAgentServiceRemoteMcpConfig({
-      server: { kind: "veryfront-api" },
-      authToken: "test-token",
-      apiMcpUrl: "https://93.184.216.34/mcp?tool_names=canonical",
-    });
-    if (!config) throw new Error("Expected API source configuration");
-    const source = wrapRemoteToolSourceWithMcpPolicy(createRemoteMCPToolSource(config), {
-      deny: ["update_file"],
-    });
-    const calledNames: string[] = [];
-    await withMockFetch(async (_url, init) => {
-      const body = JSON.parse(String(init?.body));
-      if (body.method === "tools/list") {
-        const canonical = supportsNamingMode &&
-          body.params?._meta?.["veryfront/tool-names"] !== "legacy";
-        return Response.json({
-          jsonrpc: "2.0",
-          id: body.id,
-          result: {
-            tools: ["get_file", "update_file", "gmail__list_emails"].map((name) => ({
-              name: canonical && !name.includes("__") ? `veryfront__${name}` : name,
-              description: "Tool",
-              inputSchema: {},
-            })),
-          },
-        });
-      }
-      calledNames.push(body.params.name);
-      return Response.json({
-        jsonrpc: "2.0",
-        id: body.id,
-        result: { content: [{ type: "text", text: "ok" }] },
-      });
-    }, async () => {
-      assertEquals((await source.listTools()).map((tool) => tool.name), [
-        "get_file",
-        "gmail__list_emails",
-      ]);
-      await assertRejects(
-        async () => await source.executeTool("update_file", {}),
-        Error,
-        "not allowed",
-      );
-      await source.executeTool("get_file", {});
-      assertEquals(calledNames, ["get_file"]);
-    });
-  }
 });

--- a/src/agent/service/mcp-server-config.test.ts
+++ b/src/agent/service/mcp-server-config.test.ts
@@ -1,4 +1,8 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import "#veryfront/schemas/_test-setup.ts";
+import { createRemoteMCPToolSource } from "#veryfront/tool";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { wrapRemoteToolSourceWithMcpPolicy } from "../mcp-tool-policy.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   createAgentServiceRemoteMcpConfig,
@@ -149,4 +153,55 @@ it("createAgentServiceRemoteMcpConfig gates Studio MCP by client profile", async
     "x-conversation-id": "conversation-1",
     "x-project-id": "project-2",
   });
+});
+
+it("keeps legacy invocation and deny policies across API naming versions", async () => {
+  for (const supportsNamingMode of [true, false]) {
+    const config = createAgentServiceRemoteMcpConfig({
+      server: { kind: "veryfront-api" },
+      authToken: "test-token",
+      apiMcpUrl: "https://93.184.216.34/mcp?tool_names=canonical",
+    });
+    if (!config) throw new Error("Expected API source configuration");
+    const source = wrapRemoteToolSourceWithMcpPolicy(createRemoteMCPToolSource(config), {
+      deny: ["update_file"],
+    });
+    const calledNames: string[] = [];
+    await withMockFetch(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      if (body.method === "tools/list") {
+        const canonical = supportsNamingMode &&
+          body.params?._meta?.["veryfront/tool-names"] !== "legacy";
+        return Response.json({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: {
+            tools: ["get_file", "update_file", "gmail__list_emails"].map((name) => ({
+              name: canonical && !name.includes("__") ? `veryfront__${name}` : name,
+              description: "Tool",
+              inputSchema: {},
+            })),
+          },
+        });
+      }
+      calledNames.push(body.params.name);
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: { content: [{ type: "text", text: "ok" }] },
+      });
+    }, async () => {
+      assertEquals((await source.listTools()).map((tool) => tool.name), [
+        "get_file",
+        "gmail__list_emails",
+      ]);
+      await assertRejects(
+        async () => await source.executeTool("update_file", {}),
+        Error,
+        "not allowed",
+      );
+      await source.executeTool("get_file", {});
+      assertEquals(calledNames, ["get_file"]);
+    });
+  }
 });

--- a/src/agent/service/mcp-server-config.ts
+++ b/src/agent/service/mcp-server-config.ts
@@ -92,6 +92,8 @@ function createVeryfrontApiRemoteMcpConfig(
 ): RemoteMCPToolSourceConfig {
   return {
     id: server.id ?? input.defaultSourceId ?? "veryfront-mcp",
+    // Keep persisted selectors and name-based runtime policies stable during API rollouts.
+    listMeta: { "veryfront/tool-names": "legacy" },
     endpoint: () => createProjectScopedMcpUrl(input.apiMcpUrl, input.getProjectId?.()),
     headers: () => ({ Authorization: `Bearer ${input.authToken}` }),
   };

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -2754,7 +2754,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     }
   });
 
-  it("exposes Veryfront API MCP tools requested through mcpServers policy", async () => {
+  it("preserves legacy stream policy identities with canonical-default API discovery", async () => {
     let capturedAllowedRemoteTools: string[] | undefined;
     let capturedRemoteToolNames: string[] = [];
     let capturedToolArguments: Record<string, unknown> | undefined;
@@ -2773,9 +2773,10 @@ describe("server/handlers/request/agent-stream.handler", () => {
         const request = JSON.parse(String(observeFetchRequestInit(init).body)) as {
           id: string;
           method: string;
-          params?: { arguments?: Record<string, unknown> };
+          params?: { arguments?: Record<string, unknown>; _meta?: Record<string, unknown> };
         };
         if (request.method === "tools/call") {
+          assertEquals(request.params?._meta, undefined);
           capturedToolArguments = request.params?.arguments;
           return Promise.resolve(
             new Response(
@@ -2792,7 +2793,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
               result: {
                 tools: [
                   {
-                    name: "list_uploads",
+                    name: request.params?._meta?.["veryfront/tool-names"] === "legacy"
+                      ? "list_uploads"
+                      : "veryfront__list_uploads",
                     description: "List uploads",
                     inputSchema: {
                       type: "object",
@@ -2804,7 +2807,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
                     },
                   },
                   {
-                    name: "delete_upload",
+                    name: request.params?._meta?.["veryfront/tool-names"] === "legacy"
+                      ? "delete_upload"
+                      : "veryfront__delete_upload",
                     description: "Delete upload",
                     inputSchema: { type: "object", properties: {} },
                   },

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -529,6 +529,7 @@ async function withVeryfrontPlatformRemoteTools(input: {
   const apiUrl = resolveVeryfrontApiBaseUrlFromHostEnv();
   const platformRemoteToolSource = createRemoteMCPToolSource({
     id: VERYFRONT_API_MCP_SOURCE_ID,
+    listMeta: { "veryfront/tool-names": "legacy" },
     endpoint: `${apiUrl}/mcp`,
     headers: { Authorization: `Bearer ${input.token}` },
   });

--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -19,6 +19,45 @@ import {
 import { getToolResultError } from "./result.ts";
 
 describe("tool/remote-mcp", () => {
+  it("preserves discovery metadata on every page without adding it to calls", async () => {
+    const config = {
+      id: "naming",
+      endpoint: "https://93.184.216.34/mcp",
+      listMeta: { "veryfront/tool-names": "legacy" },
+    };
+    const source = createRemoteMCPToolSource(config);
+    const requests: Record<string, unknown>[] = [];
+    await withMockFetch(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      requests.push(body.params);
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: body.method === "tools/list"
+          ? {
+            tools: [{
+              name: body.params?.cursor ? "gmail__list_emails" : "get_file",
+              description: "Read",
+              inputSchema: {},
+            }],
+            ...(body.params?.cursor ? {} : { nextCursor: "page-2" }),
+          }
+          : { content: [{ type: "text", text: "ok" }] },
+      });
+    }, async () => {
+      assertEquals((await source.listTools()).map((tool) => tool.name), [
+        "get_file",
+        "gmail__list_emails",
+      ]);
+      await source.executeTool("get_file", {});
+    });
+    assertEquals(requests, [
+      { _meta: config.listMeta },
+      { cursor: "page-2", _meta: config.listMeta },
+      { name: "get_file", arguments: {} },
+    ]);
+  });
+
   it("uses host transport only for an exact trusted endpoint", async () => {
     let transportCalls = 0;
     const createSource = createRemoteMCPToolSourceFactoryWithTransport({

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -90,6 +90,8 @@ export interface RemoteMCPToolSourceConfig {
   endpoint: ResolvableValue<string>;
   headers?: ResolvableValue<HeadersInit | undefined>;
   listMethod?: string;
+  /** Metadata sent on every tools/list page. */
+  listMeta?: Record<string, unknown>;
   callMethod?: string;
 }
 
@@ -1023,7 +1025,14 @@ function createRemoteMCPToolSourceWithFetch(
             jsonrpc: "2.0",
             id: requestId,
             method: listMethod,
-            ...(cursor !== undefined ? { params: { cursor } } : {}),
+            ...(cursor !== undefined || config.listMeta !== undefined
+              ? {
+                params: {
+                  ...(cursor !== undefined ? { cursor } : {}),
+                  ...(config.listMeta !== undefined ? { _meta: config.listMeta } : {}),
+                },
+              }
+              : {}),
           },
           getRequestFetch(endpoint),
           context?.abortSignal,

--- a/tests/integration/agent/mcp-naming-compatibility.test.ts
+++ b/tests/integration/agent/mcp-naming-compatibility.test.ts
@@ -1,0 +1,58 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { createRemoteMCPToolSource } from "#veryfront/tool";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { wrapRemoteToolSourceWithMcpPolicy } from "#veryfront/agent/mcp-tool-policy.ts";
+import { createAgentServiceRemoteMcpConfig } from "#veryfront/agent/service/mcp-server-config.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { it } from "#veryfront/testing/bdd.ts";
+
+it("keeps legacy invocation and deny policies across API naming versions", async () => {
+  for (const supportsNamingMode of [true, false]) {
+    const config = createAgentServiceRemoteMcpConfig({
+      server: { kind: "veryfront-api" },
+      authToken: "test-token",
+      apiMcpUrl: "https://93.184.216.34/mcp?tool_names=canonical",
+    });
+    if (!config) throw new Error("Expected API source configuration");
+    const source = wrapRemoteToolSourceWithMcpPolicy(createRemoteMCPToolSource(config), {
+      deny: ["update_file"],
+    });
+    const calledNames: string[] = [];
+    await withMockFetch(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      if (body.method === "tools/list") {
+        const canonical = supportsNamingMode &&
+          body.params?._meta?.["veryfront/tool-names"] !== "legacy";
+        return Response.json({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: {
+            tools: ["get_file", "update_file", "gmail__list_emails"].map((name) => ({
+              name: canonical && !name.includes("__") ? `veryfront__${name}` : name,
+              description: "Tool",
+              inputSchema: {},
+            })),
+          },
+        });
+      }
+      calledNames.push(body.params.name);
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: { content: [{ type: "text", text: "ok" }] },
+      });
+    }, async () => {
+      assertEquals((await source.listTools()).map((tool) => tool.name), [
+        "get_file",
+        "gmail__list_emails",
+      ]);
+      await assertRejects(
+        async () => await source.executeTool("update_file", {}),
+        Error,
+        "not allowed",
+      );
+      await source.executeTool("get_file", {});
+      assertEquals(calledNames, ["get_file"]);
+    });
+  }
+});


### PR DESCRIPTION
The Veryfront API can advertise `veryfront__` platform names, while saved selections and runtime allow/deny rules still use legacy names. Request legacy discovery explicitly for the Veryfront API MCP source so staggered API deployments keep tool selection, policy checks, invocation, and stream identities stable.

Service and stream-time platform discovery both request legacy names. Optional `listMeta` is sent on every `tools/list` page. Generic and Studio MCP sources keep their existing requests, and `tools/call` payloads are unchanged. Older APIs that ignore naming metadata still work.

Validation: red/green regression tests for discovery, pagination, and old/new API policy behavior; 78 tests with 223 steps passed across agent services, remote MCP, MCP policy, and hosted tool access. Targeted typecheck, formatting, lint, module boundaries, and generated documentation checks passed. The final feedback batch additionally passed 129 focused test steps, full lint, targeted typecheck, and the semantic test classification audit. Protocol compatibility coverage lives in the integration suite; pure configuration assertions remain unit tests. Local review found no actionable issues.

Part of veryfront/veryfront-issue-inbox#1055. The issue remains open until consumer rollout and staging evidence are complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility between legacy and canonical tool names for Veryfront API integrations.
  * Existing tool selections, access policies, and streamed tool names remain stable while APIs use canonical naming by default.
  * Tool discovery remains consistent across paginated results, while tool actions continue using the selected tool identity.

* **Bug Fixes**
  * Corrected tool-name translation so permitted actions continue reaching the expected remote tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->