### PR TITLE
feat(tool): support canonical Veryfront MCP identities

### DIFF
--- a/src/agent/mcp-tool-policy.test.ts
+++ b/src/agent/mcp-tool-policy.test.ts
@@ -25,6 +25,17 @@ function remoteTool(name: string): ToolDefinition {
   };
 }
 
+function platformTool(name: string, referenceName: string): ToolDefinition {
+  return {
+    ...remoteTool(name),
+    identity: {
+      type: "platform",
+      canonicalName: `veryfront__${referenceName}`,
+      referenceName,
+    },
+  };
+}
+
 function remoteSource(tools: ToolDefinition[], calls: string[] = []): RemoteToolSource {
   return {
     id: "docs",
@@ -126,6 +137,55 @@ describe("agent/mcp-tool-policy", () => {
     assertEquals(gate.filterDefinitions([remoteTool("search_docs"), remoteTool("delete_docs")]), [
       remoteTool("search_docs"),
     ]);
+  });
+
+  it("matches trusted platform aliases without widening integration names", () => {
+    const canonical = platformTool("veryfront__list_projects", "list_projects");
+    const integration = remoteTool("github__list_projects");
+    const legacyAllowedCanonicalDenied = createMcpToolPolicyGate({
+      allow: ["list_projects", "github__list_projects"],
+      deny: ["veryfront__list_projects"],
+    });
+    assertEquals(
+      legacyAllowedCanonicalDenied.filterDefinitions([canonical, integration]).map((tool) =>
+        tool.name
+      ),
+      ["github__list_projects"],
+    );
+
+    const canonicalAllowedLegacyDenied = createMcpToolPolicyGate({
+      allow: ["veryfront__list_projects", "github__list_projects"],
+      deny: ["list_projects"],
+    });
+    assertEquals(
+      canonicalAllowedLegacyDenied.filterDefinitions([canonical, integration]).map((tool) =>
+        tool.name
+      ),
+      ["github__list_projects"],
+    );
+  });
+
+  it("applies scoped platform aliases to execution after trusted discovery", async () => {
+    const calls: string[] = [];
+    const source = remoteSource([
+      platformTool("veryfront__list_projects", "list_projects"),
+      remoteTool("github__list_projects"),
+    ], calls);
+    const wrapped = wrapRemoteToolSourceWithMcpPolicy(source, {
+      allow: ["list_projects", "github__list_projects"],
+      deny: ["veryfront__list_projects"],
+    });
+
+    assertEquals((await wrapped.listTools()).map((tool) => tool.name), ["github__list_projects"]);
+    const error = captureThrown(() =>
+      wrapped.executeTool("veryfront__list_projects", { value: "blocked" })
+    );
+    assertPermissionDenied(error, 'Tool "veryfront__list_projects" is not allowed for this run');
+    assertEquals(
+      await wrapped.executeTool("github__list_projects", { value: "allowed" }),
+      { ok: true, toolName: "github__list_projects" },
+    );
+    assertEquals(calls, ["github__list_projects:allowed:undefined"]);
   });
 
   it("allow filters definition order without sorting", () => {

--- a/src/agent/mcp-tool-policy.ts
+++ b/src/agent/mcp-tool-policy.ts
@@ -5,14 +5,24 @@ import type { AgentMcpToolPolicy } from "./types.ts";
 const ReflectApply = Reflect.apply;
 const ArrayIncludes = Array.prototype.includes;
 
-function includesName(names: readonly string[], toolName: string): boolean {
-  return ReflectApply(ArrayIncludes, names, [toolName]);
+function includesName(
+  names: readonly string[],
+  toolName: string,
+  identity?: { canonicalName: string; referenceName: string },
+): boolean {
+  return ReflectApply(ArrayIncludes, names, [toolName]) ||
+    (identity !== undefined &&
+      (ReflectApply(ArrayIncludes, names, [identity.canonicalName]) ||
+        ReflectApply(ArrayIncludes, names, [identity.referenceName])));
 }
 
 export type McpToolPolicyGate = {
-  allows(toolName: string): boolean;
+  allows(toolName: string, identity?: { canonicalName: string; referenceName: string }): boolean;
   filterDefinitions<T extends { name: string }>(definitions: readonly T[]): T[];
-  assertAllowed(toolName: string): void;
+  assertAllowed(
+    toolName: string,
+    identity?: { canonicalName: string; referenceName: string },
+  ): void;
 };
 
 function isPolicyEmpty(policy: AgentMcpToolPolicy | undefined): boolean {
@@ -29,12 +39,15 @@ export function createMcpToolPolicyGate(
 ): McpToolPolicyGate {
   const deniedDetail = options?.deniedDetail ?? defaultDeniedDetail;
 
-  const allows = (toolName: string): boolean => {
+  const allows = (
+    toolName: string,
+    identity?: { canonicalName: string; referenceName: string },
+  ): boolean => {
     const deny = policy?.deny;
-    if (deny !== undefined && includesName(deny, toolName)) return false;
+    if (deny !== undefined && includesName(deny, toolName, identity)) return false;
 
     const allow = policy?.allow;
-    if (allow !== undefined) return includesName(allow, toolName);
+    if (allow !== undefined) return includesName(allow, toolName, identity);
 
     return true;
   };
@@ -43,15 +56,25 @@ export function createMcpToolPolicyGate(
     const filtered: T[] = [];
     for (let index = 0; index < definitions.length; index++) {
       const definition = definitions[index];
-      if (definition !== undefined && allows(definition.name)) {
+      if (
+        definition !== undefined && allows(
+          definition.name,
+          "identity" in definition && definition.identity !== undefined
+            ? definition.identity as { canonicalName: string; referenceName: string }
+            : undefined,
+        )
+      ) {
         filtered[filtered.length] = definition;
       }
     }
     return filtered;
   };
 
-  const assertAllowed = (toolName: string): void => {
-    if (allows(toolName)) return;
+  const assertAllowed = (
+    toolName: string,
+    identity?: { canonicalName: string; referenceName: string },
+  ): void => {
+    if (allows(toolName, identity)) return;
 
     throw PERMISSION_DENIED.create({ detail: deniedDetail(toolName) });
   };
@@ -71,13 +94,21 @@ export function wrapRemoteToolSourceWithMcpPolicy(
       options?.deniedDetail?.(toolName, source.id) ??
         defaultDeniedDetail(toolName),
   });
+  const identities = new Map<string, { canonicalName: string; referenceName: string }>();
 
   return {
     ...source,
     id: source.id,
-    listTools: async (context) => gate.filterDefinitions(await source.listTools(context)),
+    listTools: async (context) => {
+      const definitions = await source.listTools(context);
+      identities.clear();
+      for (const definition of definitions) {
+        if (definition.identity) identities.set(definition.name, definition.identity);
+      }
+      return gate.filterDefinitions(definitions);
+    },
     executeTool: (toolName, args, context) => {
-      gate.assertAllowed(toolName);
+      gate.assertAllowed(toolName, identities.get(toolName));
       return source.executeTool(toolName, args, context);
     },
   };

--- a/src/agent/service/mcp-server-config.test.ts
+++ b/src/agent/service/mcp-server-config.test.ts
@@ -23,6 +23,10 @@ it("createAgentServiceRemoteMcpConfig builds Veryfront API MCP config", async ()
     typeof config?.endpoint === "function" ? await config.endpoint() : config?.endpoint,
     "https://api.example/projects/project-1/mcp",
   );
+  assertEquals(config?.listParams, {
+    _meta: { "veryfront/tool-names": "canonical" },
+  });
+  assertEquals(config?.toolIdentity, "veryfront");
   projectId = "project-2";
   assertEquals(
     typeof config?.endpoint === "function" ? await config.endpoint() : config?.endpoint,

--- a/src/agent/service/mcp-server-config.ts
+++ b/src/agent/service/mcp-server-config.ts
@@ -94,6 +94,10 @@ function createVeryfrontApiRemoteMcpConfig(
     id: server.id ?? input.defaultSourceId ?? "veryfront-mcp",
     endpoint: () => createProjectScopedMcpUrl(input.apiMcpUrl, input.getProjectId?.()),
     headers: () => ({ Authorization: `Bearer ${input.authToken}` }),
+    listParams: {
+      _meta: { "veryfront/tool-names": "canonical" },
+    },
+    toolIdentity: "veryfront",
   };
 }
 

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -77,6 +77,7 @@
  */
 
 export type {
+  RemoteToolIdentity,
   RemoteToolSource,
   Tool,
   ToolConfig,
@@ -98,10 +99,16 @@ export type {
 export {
   createRemoteMCPToolSource,
   createRemoteMCPToolSourceFactoryWithTransport,
+  finalizeRemoteMCPToolDefinitions,
   type RemoteMCPToolSourceTransportOptions,
 } from "./remote-mcp.ts";
 export { hasToolExecutionErrorMarker, isErroredToolExecutionResult } from "./result.ts";
-export type { RemoteMCPToolSourceConfig } from "./remote-mcp.ts";
+export type {
+  RemoteMCPToolIdentityMode,
+  RemoteMCPToolListParams,
+  RemoteMCPToolSourceConfig,
+  ResolvableRemoteMCPToolListParams,
+} from "./remote-mcp.ts";
 export { createContext7ToolSource } from "./context7.ts";
 export type { Context7ToolSourceConfig } from "./context7.ts";
 export { createToolsFromHostDefinitions } from "./host-tools.ts";

--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -11,6 +11,7 @@ import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   createRemoteMCPToolSource,
   createRemoteMCPToolSourceFactoryWithTransport,
+  finalizeRemoteMCPToolDefinitions,
   MAX_REMOTE_MCP_CALL_RESPONSE_BYTES,
   MAX_REMOTE_MCP_TOOL_DEFINITIONS,
   MAX_REMOTE_MCP_TOOL_LIST_PAGES,
@@ -19,6 +20,108 @@ import {
 import { getToolResultError } from "./result.ts";
 
 describe("tool/remote-mcp", () => {
+  it("preserves static and resolved tools/list params across pagination without mutation", async () => {
+    const staticParams = {
+      _meta: { "veryfront/tool-names": "canonical" },
+      futureOption: { enabled: true },
+    };
+    const resolvedParams = {
+      _meta: { "veryfront/tool-names": "canonical" },
+      source: "resolved",
+    };
+    const context = { projectId: "project-1", marker: { retained: true } };
+    const requests: Array<Record<string, unknown>> = [];
+    let page = 0;
+    const staticSource = createRemoteMCPToolSource({
+      id: "static",
+      endpoint: "https://93.184.216.34",
+      listParams: staticParams,
+    });
+    const resolvedSource = createRemoteMCPToolSource({
+      id: "resolved",
+      endpoint: "https://93.184.216.34",
+      listParams: (receivedContext) => {
+        assertEquals(receivedContext, context);
+        return resolvedParams;
+      },
+    });
+
+    const list = (source: ReturnType<typeof createRemoteMCPToolSource>) =>
+      withMockFetch(
+        async (_input, init) => {
+          requests.push(JSON.parse(String(init?.body)));
+          page += 1;
+          return Response.json({
+            jsonrpc: "2.0",
+            id: page <= 2 ? "static:tools:list" : "resolved:tools:list",
+            result: {
+              tools: [],
+              ...(page === 1 || page === 3 ? { nextCursor: `page-${page + 1}` } : {}),
+            },
+          });
+        },
+        async () => await source.listTools(context),
+      );
+
+    await list(staticSource);
+    await list(resolvedSource);
+
+    assertEquals(requests.map((request) => request.params), [
+      staticParams,
+      { ...staticParams, cursor: "page-2" },
+      resolvedParams,
+      { ...resolvedParams, cursor: "page-4" },
+    ]);
+    assertEquals(staticParams, {
+      _meta: { "veryfront/tool-names": "canonical" },
+      futureOption: { enabled: true },
+    });
+    assertEquals(resolvedParams, {
+      _meta: { "veryfront/tool-names": "canonical" },
+      source: "resolved",
+    });
+    assertEquals(context, { projectId: "project-1", marker: { retained: true } });
+  });
+
+  it("finalizes trusted identities before filtering and rejects cross-page aliases", () => {
+    const legacy = {
+      name: "list_projects",
+      _meta: {
+        "veryfront/tool-identity": {
+          type: "platform",
+          canonicalName: "veryfront__list_projects",
+          referenceName: "list_projects",
+        },
+      },
+    };
+    const canonical = {
+      name: "veryfront__list_projects",
+      _meta: legacy._meta,
+    };
+
+    assertThrows(
+      () => finalizeRemoteMCPToolDefinitions([legacy, canonical], { identity: "veryfront" }),
+      Error,
+      'competing tool identities "list_projects" and "veryfront__list_projects"',
+    );
+    assertEquals(
+      finalizeRemoteMCPToolDefinitions([
+        legacy,
+        {
+          name: "github__list_projects",
+          _meta: {
+            "veryfront/tool-identity": {
+              type: "integration",
+              canonicalName: "github__list_projects",
+              referenceName: "github__list_projects",
+            },
+          },
+        },
+      ], { identity: "veryfront" }).map((entry) => entry.name),
+      ["list_projects", "github__list_projects"],
+    );
+  });
+
   it("uses host transport only for an exact trusted endpoint", async () => {
     let transportCalls = 0;
     const createSource = createRemoteMCPToolSourceFactoryWithTransport({

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -4,7 +4,12 @@ import type { ToolAnnotations } from "#veryfront/mcp/types.ts";
 import { snapshotBoundedJsonValue } from "#veryfront/schemas/json-value.ts";
 import type { JsonSchema } from "./schema/json-schema.ts";
 import { hasToolExecutionErrorMarker } from "./result.ts";
-import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "./types.ts";
+import type {
+  RemoteToolIdentity,
+  RemoteToolSource,
+  ToolDefinition,
+  ToolExecutionContext,
+} from "./types.ts";
 import { readResponseTextPrefix } from "#veryfront/utils/response-body.ts";
 import { guardedOutboundFetch } from "#veryfront/security/http/outbound-fetch.ts";
 
@@ -84,11 +89,26 @@ class RemoteMCPOAuthExpiredHttpError extends RemoteMCPHttpError {
 
 type ResolvableValue<T> = T | ((context?: ToolExecutionContext) => T | Promise<T>);
 
+/** JSON object merged into every tools/list request. */
+export type RemoteMCPToolListParams = Readonly<Record<string, unknown>>;
+
+/** Static or context-resolved tools/list parameters. */
+export type ResolvableRemoteMCPToolListParams = ResolvableValue<
+  RemoteMCPToolListParams | undefined
+>;
+
+/** Trusted remote identity contract understood by the framework. */
+export type RemoteMCPToolIdentityMode = "veryfront";
+
 /** Configuration used by remote MCP tool source. */
 export interface RemoteMCPToolSourceConfig {
   id?: string;
   endpoint: ResolvableValue<string>;
   headers?: ResolvableValue<HeadersInit | undefined>;
+  /** Parameters preserved on every paginated tools/list request. */
+  listParams?: ResolvableRemoteMCPToolListParams;
+  /** Enables authoritative identity validation for a trusted server contract. */
+  toolIdentity?: RemoteMCPToolIdentityMode;
   listMethod?: string;
   callMethod?: string;
 }
@@ -225,7 +245,98 @@ function normalizeParameters(inputSchema: unknown, toolName: string): JsonSchema
   return snapshot.value;
 }
 
-function normalizeToolDefinition(entry: unknown, index: number): ToolDefinition {
+function readVeryfrontToolIdentity(entry: Record<string, unknown>): RemoteToolIdentity | undefined {
+  const meta = isRecord(entry._meta) ? entry._meta : undefined;
+  const identity = entry.identity ?? meta?.["veryfront/tool-identity"];
+  if (identity === undefined) return undefined;
+  if (!isRecord(identity)) {
+    throw protocolError(
+      "Remote MCP tools/list returned malformed Veryfront tool identity metadata",
+    );
+  }
+
+  const type = identity.type;
+  const canonicalName = identity.canonicalName;
+  const referenceName = identity.referenceName;
+  if (
+    (type !== "platform" && type !== "integration" && type !== "project") ||
+    typeof canonicalName !== "string" || canonicalName.length === 0 ||
+    typeof referenceName !== "string" || referenceName.length === 0
+  ) {
+    throw protocolError(
+      "Remote MCP tools/list returned malformed Veryfront tool identity metadata",
+    );
+  }
+  if (entry.name !== canonicalName && entry.name !== referenceName) {
+    throw protocolError(
+      `Remote MCP tool "${String(entry.name)}" does not match its Veryfront identity`,
+    );
+  }
+  if (type !== "platform" && canonicalName !== referenceName) {
+    throw protocolError(
+      `Remote MCP tool "${String(entry.name)}" has invalid non-platform aliases`,
+    );
+  }
+
+  return { type, canonicalName, referenceName };
+}
+
+/**
+ * Validate a complete remote catalog before policy filtering or materialization.
+ * Original entries and order are preserved.
+ */
+export function finalizeRemoteMCPToolDefinitions<T extends { name: string }>(
+  entries: readonly T[],
+  options: { identity?: RemoteMCPToolIdentityMode } = {},
+): T[] {
+  const exactNames = new Set<string>();
+  for (const entry of entries) {
+    if (exactNames.has(entry.name)) {
+      throw protocolError(`Remote MCP tools/list returned duplicate tool name "${entry.name}"`);
+    }
+    exactNames.add(entry.name);
+  }
+
+  if (options.identity !== "veryfront") return [...entries];
+
+  const identities = entries.map((entry) =>
+    readVeryfrontToolIdentity(entry as T & Record<string, unknown>)
+  );
+  const identifiedCount = identities.filter((identity) => identity !== undefined).length;
+  // A pre-contract API has no identity metadata. Preserve its exact legacy names.
+  if (identifiedCount === 0) return [...entries];
+  if (identifiedCount !== entries.length) {
+    throw protocolError("Remote MCP tools/list mixed identified and unidentified Veryfront tools");
+  }
+
+  const claimedNames = new Map<string, string>();
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index]!;
+    const identity = identities[index]!;
+    for (
+      const claimedName of new Set([
+        entry.name,
+        identity.canonicalName,
+        identity.referenceName,
+      ])
+    ) {
+      const priorName = claimedNames.get(claimedName);
+      if (priorName !== undefined) {
+        throw protocolError(
+          `Remote MCP tools/list returned competing tool identities "${priorName}" and "${entry.name}"`,
+        );
+      }
+      claimedNames.set(claimedName, entry.name);
+    }
+  }
+  return [...entries];
+}
+
+function normalizeToolDefinition(
+  entry: unknown,
+  index: number,
+  identityMode?: RemoteMCPToolIdentityMode,
+): ToolDefinition {
   if (!isRecord(entry)) {
     throw protocolError(
       `Remote MCP tools/list returned a malformed tool definition at index ${index}`,
@@ -248,6 +359,10 @@ function normalizeToolDefinition(entry: unknown, index: number): ToolDefinition 
     description: entry.description,
     parameters: normalizeParameters(entry.inputSchema, entry.name),
   };
+  if (identityMode === "veryfront") {
+    const identity = readVeryfrontToolIdentity(entry);
+    if (identity) definition.identity = identity;
+  }
 
   if (entry.title !== undefined) {
     if (
@@ -282,7 +397,10 @@ interface NormalizedToolListPage {
   nextCursor: string | undefined;
 }
 
-function normalizeToolListPage(result: unknown): NormalizedToolListPage {
+function normalizeToolListPage(
+  result: unknown,
+  identityMode?: RemoteMCPToolIdentityMode,
+): NormalizedToolListPage {
   if (!isRecord(result)) {
     throw protocolError("Remote MCP tools/list result was not a JSON object");
   }
@@ -296,7 +414,9 @@ function normalizeToolListPage(result: unknown): NormalizedToolListPage {
     );
   }
 
-  const definitions = rawTools.map(normalizeToolDefinition);
+  const definitions = rawTools.map((entry, index) =>
+    normalizeToolDefinition(entry, index, identityMode)
+  );
   const rawNextCursor = result.nextCursor;
   let nextCursor: string | undefined;
   if (rawNextCursor !== undefined && rawNextCursor !== null) {
@@ -681,6 +801,19 @@ async function resolveHeaders(
   return finalHeaders;
 }
 
+async function resolveListParams(
+  params: ResolvableRemoteMCPToolListParams | undefined,
+  context?: ToolExecutionContext,
+): Promise<Record<string, unknown>> {
+  const resolved = params ? await resolveValue(params, context) : undefined;
+  if (resolved === undefined) return {};
+  const snapshot = snapshotBoundedJsonValue(resolved);
+  if (!snapshot.success || !isRecord(snapshot.value)) {
+    throw new TypeError("Remote MCP tools/list params must be a bounded JSON object");
+  }
+  return snapshot.value;
+}
+
 function mergeAcceptHeader(existingAccept: string | null): string {
   const requiredTypes = ["application/json", "text/event-stream"];
   const existingTypes = (existingAccept ?? "")
@@ -1009,9 +1142,9 @@ function createRemoteMCPToolSourceWithFetch(
     async listTools(context) {
       const endpoint = validateEndpoint(await resolveValue(config.endpoint, context));
       const headers = await resolveHeaders(config.headers, context);
+      const configuredListParams = await resolveListParams(config.listParams, context);
 
       const definitions: ToolDefinition[] = [];
-      const definitionNames = new Set<string>();
       const seenCursors = new Set<string>();
       let cursor: string | undefined;
       for (let page = 0; page < MAX_REMOTE_MCP_TOOL_LIST_PAGES; page += 1) {
@@ -1023,7 +1156,14 @@ function createRemoteMCPToolSourceWithFetch(
             jsonrpc: "2.0",
             id: requestId,
             method: listMethod,
-            ...(cursor !== undefined ? { params: { cursor } } : {}),
+            ...(Object.keys(configuredListParams).length > 0 || cursor !== undefined
+              ? {
+                params: {
+                  ...configuredListParams,
+                  ...(cursor !== undefined ? { cursor } : {}),
+                },
+              }
+              : {}),
           },
           getRequestFetch(endpoint),
           context?.abortSignal,
@@ -1031,7 +1171,10 @@ function createRemoteMCPToolSourceWithFetch(
         );
 
         const result = getJsonRpcResult(payload, requestId);
-        const { definitions: pageDefinitions, nextCursor } = normalizeToolListPage(result);
+        const { definitions: pageDefinitions, nextCursor } = normalizeToolListPage(
+          result,
+          config.toolIdentity,
+        );
         if (
           definitions.length + pageDefinitions.length >
             MAX_REMOTE_MCP_TOOL_DEFINITIONS
@@ -1040,18 +1183,12 @@ function createRemoteMCPToolSourceWithFetch(
             `Remote MCP tools/list cannot contain more than ${MAX_REMOTE_MCP_TOOL_DEFINITIONS} tools`,
           );
         }
-        for (const definition of pageDefinitions) {
-          if (definitionNames.has(definition.name)) {
-            throw protocolError(
-              `Remote MCP tools/list returned duplicate tool name "${definition.name}"`,
-            );
-          }
-          definitionNames.add(definition.name);
-          definitions.push(definition);
-        }
+        definitions.push(...pageDefinitions);
 
         if (nextCursor === undefined) {
-          return definitions;
+          return finalizeRemoteMCPToolDefinitions(definitions, {
+            identity: config.toolIdentity,
+          });
         }
         if (seenCursors.has(nextCursor)) {
           throw protocolError(

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -221,6 +221,15 @@ export interface ToolDefinition {
   parameters: JsonSchema;
   title?: string;
   annotations?: ToolAnnotations;
+  /** Trusted remote identity metadata. The observed wire name remains in `name`. */
+  identity?: RemoteToolIdentity;
+}
+
+/** Authoritative identity metadata supplied by a trusted remote tool server. */
+export interface RemoteToolIdentity {
+  type: "platform" | "integration" | "project";
+  canonicalName: string;
+  referenceName: string;
 }
 
 /**


### PR DESCRIPTION
Links veryfront/veryfront-issue-inbox#1055.

This Code-library lane adds typed `tools/list` params with resolver support, preserves them across pagination, exports one trusted Veryfront identity finalizer, enables canonical discovery for the default Veryfront API source, and makes MCP allow/deny policy match authoritative platform aliases with deny precedence. Generic third-party MCP sources retain exact-name behavior and receive no Veryfront metadata.

Out of scope: API routes and mutation normalization, Agent wrapper/package adoption, Studio rendering and persistence, package publication, deployment, and issue closure.

Red/green evidence: the new focused tests initially failed because the list-param/finalizer exports and behavior did not exist. After implementation, the focused suite passes 65 assertions.

Verification:

- `PATH=/tmp/deno-2.7.7:$PATH deno task test:file src/tool/remote-mcp.test.ts src/agent/mcp-tool-policy.test.ts src/agent/service/mcp-server-config.test.ts`
- `deno check` on modified implementation files
- Broader repository verification and exact-head Codex review will be added before readiness.

Staging plan: after API metadata support and Agent package adoption are merged through their separate lanes, capture canonical `tools/list` packets, verify old-API legacy fallback, and run the persisted/scoped allow/deny compatibility matrix. This PR alone cannot close the inbox issue.
