### PR TITLE
feat(agent): emit runtime_context as a native RUNTIME_EVENT_RECORDED event

### DIFF
--- a/src/agent/ag-ui/encoder.test.ts
+++ b/src/agent/ag-ui/encoder.test.ts
@@ -273,9 +273,10 @@ describe("agent/ag-ui-encoder", () => {
         data: { runStartedAtUtc: "2026-07-19T07:30:00.000Z" },
       }),
       [{
-        event: "Custom",
+        event: "RuntimeEventRecorded",
         payload: {
-          name: "veryfront.runtime_context",
+          runtime: "veryfront",
+          kind: "runtime_context",
           value: { runStartedAtUtc: "2026-07-19T07:30:00.000Z" },
         },
       }],

--- a/src/agent/ag-ui/native-run-events.test.ts
+++ b/src/agent/ag-ui/native-run-events.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildChildRunStatusChangedEvent,
@@ -450,6 +450,28 @@ describe("agent/ag-ui-native-run-events", () => {
           type: "RUNTIME_EVENT_RECORDED",
         },
       },
+    );
+  });
+
+  it("rejects a runtime event recorded with an invalid runtime, kind, or value", () => {
+    // `runtime`/`kind` are typed `string`, which accepts empty text, and
+    // `value` is typed `unknown`, which accepts `undefined`; but the API
+    // catalog's RUNTIME_EVENT_RECORDED variant requires non-empty strings
+    // and a JSON value. This builder has callers outside this module's own
+    // dispatcher (e.g. a future codex-runtime producer), so it must reject
+    // those on its own rather than trusting the caller's static types.
+    assertThrows(() =>
+      buildRuntimeEventRecordedEvent({ runtime: "", kind: "runtime_context", value: {} })
+    );
+    assertThrows(() =>
+      buildRuntimeEventRecordedEvent({ runtime: "veryfront", kind: "", value: {} })
+    );
+    assertThrows(() =>
+      buildRuntimeEventRecordedEvent({
+        runtime: "veryfront",
+        kind: "runtime_context",
+        value: undefined,
+      })
     );
   });
 

--- a/src/agent/ag-ui/native-run-events.test.ts
+++ b/src/agent/ag-ui/native-run-events.test.ts
@@ -7,6 +7,7 @@ import {
   buildFileAttachedEvent,
   buildInputRequestLifecycleEvent,
   buildNativeRunEventFrame,
+  buildRuntimeEventRecordedEvent,
   buildToolCallStatusChangedEvent,
   buildUrlCitedEvent,
   isNativeRunEventName,
@@ -57,6 +58,7 @@ describe("agent/ag-ui-native-run-events", () => {
       "UrlCited",
       "DocumentCited",
       "FileAttached",
+      "RuntimeEventRecorded",
     ]);
     assertEquals(
       Object.values(nativeRunEventTypes),
@@ -69,7 +71,7 @@ describe("agent/ag-ui-native-run-events", () => {
     );
   });
 
-  it("accepts the six legacy custom names and rejects everything else", () => {
+  it("accepts the seven legacy custom names and rejects everything else", () => {
     for (
       const name of [
         "tool-call-status",
@@ -78,6 +80,7 @@ describe("agent/ag-ui-native-run-events", () => {
         "source-url",
         "source-document",
         "file",
+        "veryfront.runtime_context",
       ]
     ) {
       assertEquals(isNativeRunEventName(name), true, name);
@@ -423,6 +426,33 @@ describe("agent/ag-ui-native-run-events", () => {
     }
   });
 
+  it("builds both emission shapes for a runtime event recorded", () => {
+    const runtimeContext = {
+      currentTimeUtc: "2026-09-09T00:00:00.000Z",
+      currentDateUtc: "2026-09-09",
+      runStartedAtUtc: "2026-09-09T00:00:00.000Z",
+    };
+    assertEquals(
+      buildRuntimeEventRecordedEvent({
+        runtime: "veryfront",
+        kind: "runtime_context",
+        value: runtimeContext,
+      }),
+      {
+        live: {
+          event: "RuntimeEventRecorded",
+          payload: { runtime: "veryfront", kind: "runtime_context", value: runtimeContext },
+        },
+        durable: {
+          runtime: "veryfront",
+          kind: "runtime_context",
+          value: runtimeContext,
+          type: "RUNTIME_EVENT_RECORDED",
+        },
+      },
+    );
+  });
+
   it("routes every legacy name through the dispatcher", () => {
     assertEquals(
       buildNativeRunEventFrame({
@@ -461,6 +491,40 @@ describe("agent/ag-ui-native-run-events", () => {
       })?.live.event,
       "FileAttached",
     );
+    assertEquals(
+      buildNativeRunEventFrame({
+        name: "veryfront.runtime_context",
+        value: {
+          currentTimeUtc: "2026-09-09T00:00:00.000Z",
+          currentDateUtc: "2026-09-09",
+          runStartedAtUtc: "2026-09-09T00:00:00.000Z",
+        },
+      }),
+      {
+        live: {
+          event: "RuntimeEventRecorded",
+          payload: {
+            runtime: "veryfront",
+            kind: "runtime_context",
+            value: {
+              currentTimeUtc: "2026-09-09T00:00:00.000Z",
+              currentDateUtc: "2026-09-09",
+              runStartedAtUtc: "2026-09-09T00:00:00.000Z",
+            },
+          },
+        },
+        durable: {
+          runtime: "veryfront",
+          kind: "runtime_context",
+          value: {
+            currentTimeUtc: "2026-09-09T00:00:00.000Z",
+            currentDateUtc: "2026-09-09",
+            runStartedAtUtc: "2026-09-09T00:00:00.000Z",
+          },
+          type: "RUNTIME_EVENT_RECORDED",
+        },
+      },
+    );
   });
 
   it("returns null for a name or value that has no native frame", () => {
@@ -493,6 +557,11 @@ describe("agent/ag-ui-native-run-events", () => {
       }),
       null,
       "a file-change value is FILES_CHANGED on the legacy path, never FileAttached",
+    );
+    assertEquals(
+      buildNativeRunEventFrame({ name: "veryfront.runtime_context", value: null }),
+      null,
+      "a non-record value cannot become a RuntimeEventRecorded payload",
     );
   });
 });

--- a/src/agent/ag-ui/native-run-events.ts
+++ b/src/agent/ag-ui/native-run-events.ts
@@ -1,3 +1,5 @@
+import { getJsonValueSchema, getNonEmptyStringSchema } from "#veryfront/schemas/index.ts";
+
 /**
  * Native run event vocabulary shared by every emission path.
  *
@@ -352,11 +354,22 @@ export interface RuntimeEventRecordedInput {
   value: unknown;
 }
 
-/** Build the runtime event recorded frames. */
+/**
+ * Build the runtime event recorded frames.
+ *
+ * Validates against the catalog's own constraints -- `runtime`/`kind` non-empty
+ * strings, `value` a bounded JSON value -- rather than trusting the caller's
+ * static `string`/`unknown` types, since this builder (unlike the other seven)
+ * has callers outside this module's own dispatcher that supply the catalog
+ * fields directly.
+ */
 export function buildRuntimeEventRecordedEvent(
   input: RuntimeEventRecordedInput,
 ): NativeRunEventFrame {
-  return toFrame(RUNTIME_EVENT_RECORDED, { ...input });
+  const runtime = getNonEmptyStringSchema().parse(input.runtime);
+  const kind = getNonEmptyStringSchema().parse(input.kind);
+  const value = getJsonValueSchema().parse(input.value);
+  return toFrame(RUNTIME_EVENT_RECORDED, { runtime, kind, value });
 }
 
 /** Routing input for one custom event name and its value. */

--- a/src/agent/ag-ui/native-run-events.ts
+++ b/src/agent/ag-ui/native-run-events.ts
@@ -1,7 +1,7 @@
 /**
  * Native run event vocabulary shared by every emission path.
  *
- * Veryfront Code used to wrap these seven occurrences in an AG-UI `Custom`
+ * Veryfront Code used to wrap these eight occurrences in an AG-UI `Custom`
  * frame and let the API translate the custom name back into a type. The API
  * now accepts the native names, so this module owns the list once: the wire
  * name a live SSE frame carries, the stored type a durable record carries, and
@@ -45,6 +45,11 @@ export const NATIVE_RUN_EVENTS = [
     legacyCustomName: "source-document",
   },
   { wireName: "FileAttached", storedType: "FILE_ATTACHED", legacyCustomName: "file" },
+  {
+    wireName: "RuntimeEventRecorded",
+    storedType: "RUNTIME_EVENT_RECORDED",
+    legacyCustomName: "veryfront.runtime_context",
+  },
 ] as const satisfies readonly NativeRunEventDefinition[];
 
 type NativeRunEventEntry = (typeof NATIVE_RUN_EVENTS)[number];
@@ -78,6 +83,7 @@ export const nativeRunEventTypes = {
   urlCited: "URL_CITED",
   documentCited: "DOCUMENT_CITED",
   fileAttached: "FILE_ATTACHED",
+  runtimeEventRecorded: "RUNTIME_EVENT_RECORDED",
 } as const;
 
 /** Stored type for each native wire name, for SSE readers. */
@@ -136,6 +142,7 @@ const CHILD_RUN_STATUS_CHANGED = NATIVE_RUN_EVENTS[3];
 const URL_CITED = NATIVE_RUN_EVENTS[4];
 const DOCUMENT_CITED = NATIVE_RUN_EVENTS[5];
 const FILE_ATTACHED = NATIVE_RUN_EVENTS[6];
+const RUNTIME_EVENT_RECORDED = NATIVE_RUN_EVENTS[7];
 
 // Keep application fields from overriding the native type or transport timing
 // when an open custom value becomes a flat native payload.
@@ -330,6 +337,28 @@ export function buildFileAttachedEvent(source: Record<string, unknown>): NativeR
   return toFrame(FILE_ATTACHED, payload);
 }
 
+/**
+ * Fields the API catalog's `RUNTIME_EVENT_RECORDED` variant requires:
+ * `runtime` and `kind` non-empty strings, `value` any JSON value but never
+ * `undefined`. This is the catch-all diagnostics type for a runtime-native
+ * event with no AG-UI equivalent (the API catalog's own description
+ * mentions codex thread/session events as a future producer), so unlike the
+ * other seven builders this one does not derive its shape from a fixed
+ * source chunk -- the caller supplies the catalog fields directly.
+ */
+export interface RuntimeEventRecordedInput {
+  runtime: string;
+  kind: string;
+  value: unknown;
+}
+
+/** Build the runtime event recorded frames. */
+export function buildRuntimeEventRecordedEvent(
+  input: RuntimeEventRecordedInput,
+): NativeRunEventFrame {
+  return toFrame(RUNTIME_EVENT_RECORDED, { ...input });
+}
+
 /** Routing input for one custom event name and its value. */
 export interface NativeRunEventRoutingInput {
   name: string;
@@ -389,6 +418,18 @@ export function buildNativeRunEventFrame(
           readString(record.mediaType)
         ? buildFileAttachedEvent(record)
         : null;
+    case "veryfront.runtime_context":
+      // The one producer (runtime/index.ts's #streamWithinTurn) always sends
+      // the whole AgentRunRuntimeContext snapshot as the chunk's `data`, so
+      // `record` (already guarded non-null above) is the payload's `value`
+      // field wholesale; `runtime`/`kind` are this producer's own constants,
+      // not read off the value, since this legacy name only ever carried the
+      // context object itself.
+      return buildRuntimeEventRecordedEvent({
+        runtime: "veryfront",
+        kind: "runtime_context",
+        value: record,
+      });
     default:
       return null;
   }

--- a/src/agent/conversation/legacy-run-read-adapter.test.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.test.ts
@@ -18,6 +18,7 @@ import {
   buildDocumentCitedEvent,
   buildFileAttachedEvent,
   buildInputRequestLifecycleEvent,
+  buildRuntimeEventRecordedEvent,
   buildToolCallStatusChangedEvent,
   buildUrlCitedEvent,
   NATIVE_RUN_EVENTS,
@@ -1567,6 +1568,27 @@ describe("conversation run lifecycle read adapter", () => {
           type: "CUSTOM",
           name: "file",
           value: { type: "file", mediaType: "text/plain", path: "notes.txt" },
+        },
+      },
+      {
+        description: "RUNTIME_EVENT_RECORDED",
+        native: buildRuntimeEventRecordedEvent({
+          runtime: "veryfront",
+          kind: "runtime_context",
+          value: {
+            currentTimeUtc: "2026-09-09T00:00:00.000Z",
+            currentDateUtc: "2026-09-09",
+            runStartedAtUtc: "2026-09-09T00:00:00.000Z",
+          },
+        }).durable,
+        customTwin: {
+          type: "CUSTOM",
+          name: "veryfront.runtime_context",
+          value: {
+            currentTimeUtc: "2026-09-09T00:00:00.000Z",
+            currentDateUtc: "2026-09-09",
+            runStartedAtUtc: "2026-09-09T00:00:00.000Z",
+          },
         },
       },
     ];

--- a/src/agent/conversation/legacy-run-read-adapter.test.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.test.ts
@@ -1619,6 +1619,28 @@ describe("conversation run lifecycle read adapter", () => {
       assertEquals(customFramesFor(1, native), customFramesFor(1, customTwin));
     });
 
+    it(
+      "does not reconstruct a non-veryfront RUNTIME_EVENT_RECORDED as the runtime_context twin",
+      () => {
+        // RUNTIME_EVENT_RECORDED is the API catalog's generic diagnostics
+        // shape and has other producers (e.g. the codex runtime) with other
+        // runtime/kind pairs. Only the exact veryfront/runtime_context pair
+        // may unwrap to the legacy `veryfront.runtime_context` CUSTOM twin;
+        // every other pair must surface as its own generic custom record
+        // instead of a false runtime_context.
+        const native = buildRuntimeEventRecordedEvent({
+          runtime: "codex",
+          kind: "stderr",
+          value: { line: "boom" },
+        }).durable;
+
+        assertEquals(
+          customFramesFor(2, { ...native, ...v2Envelope(1, "codex-runtime-event") }),
+          [{ type: "custom", name: "codex.stderr", data: { line: "boom" } }],
+        );
+      },
+    );
+
     it("reads a TOOL_CALL_STATUS_CHANGED durable record as its CUSTOM twin on the version 1 reader", () => {
       const { native, customTwin } = cases.find((entry) =>
         entry.description === "TOOL_CALL_STATUS_CHANGED"

--- a/src/agent/conversation/legacy-run-read-adapter.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.ts
@@ -67,13 +67,19 @@ function readNativeAsLegacyCustom(
   }
   if (definition.storedType === "RUNTIME_EVENT_RECORDED") {
     // The legacy `veryfront.runtime_context` CUSTOM twin carried the bare
-    // AgentRunRuntimeContext object as its value; the native payload wraps
-    // that same object as `{ runtime, kind, value }` to match the API
-    // catalog's generic diagnostics shape (RUNTIME_EVENT_RECORDED has other
-    // producers with other runtimes/kinds, so the wrapper is required
-    // there). Unwrap back to the twin's own value here, the same way the
-    // citation/file case below restores a field the native payload dropped.
-    return { name: definition.legacyCustomName, value: value.value };
+    // AgentRunRuntimeContext object as its value, produced only for the
+    // veryfront/runtime_context pair; the native payload wraps that same
+    // object as `{ runtime, kind, value }` to match the API catalog's
+    // generic diagnostics shape (RUNTIME_EVENT_RECORDED has other producers
+    // with other runtimes/kinds, e.g. the codex runtime, so the wrapper is
+    // required there). Only that exact pair unwraps to the legacy twin here,
+    // the same way the citation/file case below restores a field the native
+    // payload dropped; any other runtime/kind becomes its own generic custom
+    // record instead of a false veryfront.runtime_context.
+    if (value.runtime === "veryfront" && value.kind === "runtime_context") {
+      return { name: definition.legacyCustomName, value: value.value };
+    }
+    return { name: `${String(value.runtime)}.${String(value.kind)}`, value: value.value };
   }
   if (
     definition.storedType === "INPUT_REQUEST_CREATED" ||

--- a/src/agent/conversation/legacy-run-read-adapter.ts
+++ b/src/agent/conversation/legacy-run-read-adapter.ts
@@ -56,7 +56,7 @@ const DURABLE_ENVELOPE_KEYS = [
  */
 function readNativeAsLegacyCustom(
   event: Record<string, unknown>,
-): { name: string; value: Record<string, unknown> } | null {
+): { name: string; value: unknown } | null {
   const definition = typeof event.type === "string"
     ? NATIVE_STORED_TYPE_TO_LEGACY.get(event.type)
     : undefined;
@@ -64,6 +64,16 @@ function readNativeAsLegacyCustom(
   const value = { ...event };
   for (const key of DURABLE_ENVELOPE_KEYS) {
     delete value[key];
+  }
+  if (definition.storedType === "RUNTIME_EVENT_RECORDED") {
+    // The legacy `veryfront.runtime_context` CUSTOM twin carried the bare
+    // AgentRunRuntimeContext object as its value; the native payload wraps
+    // that same object as `{ runtime, kind, value }` to match the API
+    // catalog's generic diagnostics shape (RUNTIME_EVENT_RECORDED has other
+    // producers with other runtimes/kinds, so the wrapper is required
+    // there). Unwrap back to the twin's own value here, the same way the
+    // citation/file case below restores a field the native payload dropped.
+    return { name: definition.legacyCustomName, value: value.value };
   }
   if (
     definition.storedType === "INPUT_REQUEST_CREATED" ||

--- a/src/agent/conversation/run-events.test.ts
+++ b/src/agent/conversation/run-events.test.ts
@@ -277,6 +277,32 @@ describe("agent/conversation-run-events", () => {
     );
   });
 
+  it("encodes native runtime event chunks as native durable records", () => {
+    const encoder = new ConversationRunEventEncoder();
+    assertEquals(
+      encoder.encode({
+        type: "data-veryfront.runtime_context",
+        data: {
+          currentTimeUtc: "2026-09-09T00:00:00.000Z",
+          currentDateUtc: "2026-09-09",
+          runStartedAtUtc: "2026-09-09T00:00:00.000Z",
+        },
+      }),
+      [
+        {
+          type: conversationRunEventTypes.runtimeEventRecorded,
+          runtime: "veryfront",
+          kind: "runtime_context",
+          value: {
+            currentTimeUtc: "2026-09-09T00:00:00.000Z",
+            currentDateUtc: "2026-09-09",
+            runStartedAtUtc: "2026-09-09T00:00:00.000Z",
+          },
+        },
+      ],
+    );
+  });
+
   it("keeps state chunks and unknown data names custom", () => {
     const encoder = new ConversationRunEventEncoder();
     assertEquals(

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -780,6 +780,21 @@ describe("chat/ag-ui", () => {
     ]);
   });
 
+  it("does not mistake a non-veryfront runtime event for runtime context", () => {
+    // RUNTIME_EVENT_RECORDED is the API catalog's generic diagnostics shape
+    // and accepts any non-empty runtime/kind pair (e.g. a codex thread or
+    // session event) -- only the exact veryfront/runtime_context pair may
+    // become the legacy `data-veryfront.runtime_context` chunk.
+    ensureTestSchemaValidator();
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const frames = 'event: RuntimeEventRecorded\ndata: {"runtime":"codex","kind":"stderr",' +
+      '"value":{"line":"boom"}}\n\n';
+
+    assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
+      { type: "data-codex.stderr", data: { line: "boom" } },
+    ]);
+  });
+
   it("falls back to a data chunk when an attachment cannot render", () => {
     ensureTestSchemaValidator();
     const state = createAgUiChatEventDecoderState({ validationMode: "strict" });

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -749,6 +749,8 @@ describe("chat/ag-ui", () => {
       'event: InputRequestUpdated\ndata: {"inputRequest":{"id":"req-1"}}\n\n',
       'event: ChildRunStatusChanged\ndata: {"toolCallId":"t","childRunId":"r",' +
       '"status":"running"}\n\n',
+      'event: RuntimeEventRecorded\ndata: {"runtime":"veryfront","kind":"runtime_context",' +
+      '"value":{"currentTimeUtc":"2026-09-09T00:00:00.000Z"}}\n\n',
     ].join("");
 
     assertEquals(decodeAgUiSseChunk(state, frames).events.flatMap((entry) => entry.chatEvents), [
@@ -770,6 +772,10 @@ describe("chat/ag-ui", () => {
       {
         type: "data-veryfront.invoke_agent.lifecycle",
         data: { toolCallId: "t", childRunId: "r", status: "running" },
+      },
+      {
+        type: "data-veryfront.runtime_context",
+        data: { currentTimeUtc: "2026-09-09T00:00:00.000Z" },
       },
     ]);
   });
@@ -1162,10 +1168,10 @@ describe("chat/ag-ui", () => {
   it("decodes every native run event wire name NATIVE_RUN_EVENTS defines", () => {
     ensureTestSchemaValidator();
     // NATIVE_RUN_EVENTS (src/agent/ag-ui/native-run-events.ts) is the
-    // producer's source of truth for the seven native wire names; this
+    // producer's source of truth for the eight native wire names; this
     // decoder keeps its own copy in AG_UI_WIRE_EVENT_NAMES rather than
     // importing that module, to keep the agent tree off the client bundle
-    // graph. Nothing else catches the two lists drifting apart: an eighth
+    // graph. Nothing else catches the two lists drifting apart: a ninth
     // native type added there would be silently dropped here, which is the
     // exact failure P9 exists to prevent.
     for (const { wireName } of NATIVE_RUN_EVENTS) {
@@ -1294,9 +1300,9 @@ describe("chat/ag-ui without a registered SchemaValidator", () => {
   });
 
   it("decodes native run event frames through the hand-rolled validator too", () => {
-    // The seven native arms in isValidAgUiPayload only run on this path, so
+    // The eight native arms in isValidAgUiPayload only run on this path, so
     // the zod-backed coverage above does not exercise them at all. Reuse the
-    // same seven-frame string the schema-validated twin-equality test uses.
+    // same eight-frame string the schema-validated twin-equality test uses.
     unregister("SchemaValidator");
     try {
       const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
@@ -1312,6 +1318,8 @@ describe("chat/ag-ui without a registered SchemaValidator", () => {
         'event: InputRequestUpdated\ndata: {"inputRequest":{"id":"req-1"}}\n\n',
         'event: ChildRunStatusChanged\ndata: {"toolCallId":"t","childRunId":"r",' +
         '"status":"running"}\n\n',
+        'event: RuntimeEventRecorded\ndata: {"runtime":"veryfront","kind":"runtime_context",' +
+        '"value":{"currentTimeUtc":"2026-09-09T00:00:00.000Z"}}\n\n',
       ].join("");
 
       assertEquals(
@@ -1340,6 +1348,10 @@ describe("chat/ag-ui without a registered SchemaValidator", () => {
           {
             type: "data-veryfront.invoke_agent.lifecycle",
             data: { toolCallId: "t", childRunId: "r", status: "running" },
+          },
+          {
+            type: "data-veryfront.runtime_context",
+            data: { currentTimeUtc: "2026-09-09T00:00:00.000Z" },
           },
         ],
         "the hand-rolled validator must decode native frames the same way the zod schema does",

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -129,6 +129,7 @@ const AG_UI_WIRE_EVENT_NAMES = [
   "UrlCited",
   "DocumentCited",
   "FileAttached",
+  "RuntimeEventRecorded",
   "RunFinished",
   "RunError",
 ] as const;
@@ -595,6 +596,14 @@ export const getAgUiWireEventSchema = defineSchema((v) =>
       }).passthrough(),
     }),
     v.object({
+      eventName: v.literal("RuntimeEventRecorded"),
+      payload: v.object({
+        runtime: v.string().min(1),
+        kind: v.string().min(1),
+        value: v.unknown(),
+      }).passthrough(),
+    }),
+    v.object({
       eventName: v.literal("RunFinished"),
       payload: v.object({ metadata: getAgUiRunFinishedMetadataSchema().optional() }),
     }),
@@ -724,6 +733,10 @@ function isValidAgUiPayload(
 
     case "FileAttached":
       return hasStringField(payload, "mediaType");
+
+    case "RuntimeEventRecorded":
+      return hasStringField(payload, "runtime") && hasStringField(payload, "kind") &&
+        "value" in payload;
 
     case "ToolCallResult":
       return hasStringField(payload, "toolCallId") &&
@@ -1091,6 +1104,17 @@ function mapWireEventToChatEvents(
         ...(typeof filename === "string" ? { filename } : {}),
       }];
     }
+
+    case "RuntimeEventRecorded":
+      // The Custom twin's data chunk carried the bare runtime context value,
+      // not the API's { runtime, kind, value } wrapper -- veryfront-code's
+      // one producer today (runtime/index.ts's #streamWithinTurn) always
+      // sent the whole snapshot object as `data`, so unwrap the same way
+      // legacy-run-read-adapter.ts's durable twin does.
+      return [{
+        type: "data-veryfront.runtime_context",
+        data: wireEvent.payload.value,
+      }];
 
     case "RunFinished":
       state.toolCalls.clear();

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -1105,16 +1105,33 @@ function mapWireEventToChatEvents(
       }];
     }
 
-    case "RuntimeEventRecorded":
-      // The Custom twin's data chunk carried the bare runtime context value,
-      // not the API's { runtime, kind, value } wrapper -- veryfront-code's
-      // one producer today (runtime/index.ts's #streamWithinTurn) always
-      // sent the whole snapshot object as `data`, so unwrap the same way
-      // legacy-run-read-adapter.ts's durable twin does.
+    case "RuntimeEventRecorded": {
+      const { runtime, kind, value } = wireEvent.payload;
+      if (runtime === "veryfront" && kind === "runtime_context") {
+        // The Custom twin's data chunk carried the bare runtime context value,
+        // not the API's { runtime, kind, value } wrapper -- veryfront-code's
+        // one producer today (runtime/index.ts's #streamWithinTurn) always
+        // sent the whole snapshot object as `data`, so unwrap the same way
+        // legacy-run-read-adapter.ts's durable twin does.
+        return [{
+          type: "data-veryfront.runtime_context",
+          data: value,
+        }];
+      }
+
+      // RUNTIME_EVENT_RECORDED is the API catalog's generic diagnostics
+      // shape and accepts any non-empty runtime/kind pair (the catalog's own
+      // description mentions codex thread/session events as a future
+      // producer), so any pair other than veryfront/runtime_context is not
+      // this repo's legacy twin. Expose it as its own generic chat chunk the
+      // same way the "Custom" case above falls back to `data-${name}` for an
+      // unrecognized custom name, instead of mislabeling it as Veryfront's
+      // runtime context.
       return [{
-        type: "data-veryfront.runtime_context",
-        data: wireEvent.payload.value,
+        type: `data-${runtime}.${kind}`,
+        data: value,
       }];
+    }
 
     case "RunFinished":
       state.toolCalls.clear();

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -388,6 +388,27 @@ describe("internal-agents/ag-ui-sse", () => {
     );
   });
 
+  it("declares RuntimeEventRecorded in the payload allow-list with extra fields intact", () => {
+    // The eighth native wire name (see native-run-events.ts's P12 decision):
+    // an API-catalog diagnostics record with no fixed shape beyond
+    // runtime/kind/value, so this allow-list entry is `.passthrough()`-ed
+    // like its seven siblings rather than declaring extra fields.
+    const payload = new TextDecoder().decode(
+      formatAgUiEvent("RuntimeEventRecorded", {
+        runtime: "veryfront",
+        kind: "runtime_context",
+        value: { currentTimeUtc: "2026-09-09T00:00:00.000Z" },
+        emittedAt: 8,
+      }),
+    );
+
+    assertEquals(
+      payload,
+      'event: RuntimeEventRecorded\ndata: {"runtime":"veryfront","kind":"runtime_context",' +
+        '"value":{"currentTimeUtc":"2026-09-09T00:00:00.000Z"},"emittedAt":8}\n\n',
+    );
+  });
+
   it("declares the seven native run event names in the payload allow-list with extra fields intact", () => {
     // M3: the seven native wire names used to have no schema entry, so they
     // took formatAgUiEvent's unvalidated pass-through branch instead of this

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -176,6 +176,15 @@ function buildAgUiEventPayloadSchemas(): Record<string, Schema<Record<string, un
       url: v.unknown().optional(),
       filename: v.unknown().optional(),
     }).passthrough(),
+    // The eighth native run event wire name (see native-run-events.ts):
+    // an API-catalog diagnostics record with no AG-UI equivalent. `value`
+    // is unconstrained JSON per the catalog's `requiredUnknown`, so it is
+    // passed through unvalidated the same way Custom's own `value` is.
+    RuntimeEventRecorded: withTiming({
+      runtime: v.string().min(1),
+      kind: v.string().min(1),
+      value: v.unknown(),
+    }).passthrough(),
   };
   return schemas;
 }
@@ -216,7 +225,8 @@ type AgUiEventName =
   | "ChildRunStatusChanged"
   | "UrlCited"
   | "DocumentCited"
-  | "FileAttached";
+  | "FileAttached"
+  | "RuntimeEventRecorded";
 
 export function formatAgUiEvent(event: string, payload: Record<string, unknown>): Uint8Array {
   const eventNameMatch = AG_UI_EVENT_NAME_PATTERN.exec(event);

--- a/tests/fixtures/contracts/native-run-events.json
+++ b/tests/fixtures/contracts/native-run-events.json
@@ -35,7 +35,13 @@
           "requestedResponderType": "human",
           "title": "Choose a deployment target",
           "description": null,
-          "fields": [{ "type": "confirm", "name": "confirmed", "label": "Confirm?" }],
+          "fields": [
+            {
+              "type": "confirm",
+              "name": "confirmed",
+              "label": "Confirm?"
+            }
+          ],
           "recommendations": null,
           "metadata": null,
           "createdAt": "2026-09-09T00:00:00.000Z",
@@ -58,7 +64,13 @@
         "requestedResponderType": "human",
         "title": "Choose a deployment target",
         "description": null,
-        "fields": [{ "type": "confirm", "name": "confirmed", "label": "Confirm?" }],
+        "fields": [
+          {
+            "type": "confirm",
+            "name": "confirmed",
+            "label": "Confirm?"
+          }
+        ],
         "recommendations": null,
         "metadata": null,
         "createdAt": "2026-09-09T00:00:00.000Z",
@@ -87,7 +99,13 @@
           "requestedResponderType": "human",
           "title": "Choose a deployment target",
           "description": null,
-          "fields": [{ "type": "confirm", "name": "confirmed", "label": "Confirm?" }],
+          "fields": [
+            {
+              "type": "confirm",
+              "name": "confirmed",
+              "label": "Confirm?"
+            }
+          ],
           "recommendations": null,
           "metadata": null,
           "createdAt": "2026-09-09T00:00:00.000Z",
@@ -110,7 +128,13 @@
         "requestedResponderType": "human",
         "title": "Choose a deployment target",
         "description": null,
-        "fields": [{ "type": "confirm", "name": "confirmed", "label": "Confirm?" }],
+        "fields": [
+          {
+            "type": "confirm",
+            "name": "confirmed",
+            "label": "Confirm?"
+          }
+        ],
         "recommendations": null,
         "metadata": null,
         "createdAt": "2026-09-09T00:00:00.000Z",
@@ -211,6 +235,32 @@
       "mediaType": "application/pdf",
       "filename": "report.pdf",
       "type": "FILE_ATTACHED"
+    }
+  },
+  {
+    "storedType": "RUNTIME_EVENT_RECORDED",
+    "legacyCustomName": "veryfront.runtime_context",
+    "live": {
+      "event": "RuntimeEventRecorded",
+      "payload": {
+        "runtime": "veryfront",
+        "kind": "runtime_context",
+        "value": {
+          "currentTimeUtc": "2026-09-09T00:00:00.000Z",
+          "currentDateUtc": "2026-09-09",
+          "runStartedAtUtc": "2026-09-09T00:00:00.000Z"
+        }
+      }
+    },
+    "durable": {
+      "runtime": "veryfront",
+      "kind": "runtime_context",
+      "value": {
+        "currentTimeUtc": "2026-09-09T00:00:00.000Z",
+        "currentDateUtc": "2026-09-09",
+        "runStartedAtUtc": "2026-09-09T00:00:00.000Z"
+      },
+      "type": "RUNTIME_EVENT_RECORDED"
     }
   }
 ]

--- a/tests/integration/semantic-unit-boundary/src/agent/ag-ui/native-run-events-contract.test.ts
+++ b/tests/integration/semantic-unit-boundary/src/agent/ag-ui/native-run-events-contract.test.ts
@@ -9,6 +9,7 @@ import {
   buildDocumentCitedEvent,
   buildFileAttachedEvent,
   buildInputRequestLifecycleEvent,
+  buildRuntimeEventRecordedEvent,
   buildToolCallStatusChangedEvent,
   buildUrlCitedEvent,
   NATIVE_RUN_EVENTS,
@@ -25,7 +26,7 @@ const FIXTURE_URL = new URL(
 // The veryfront-api copy of this file pins the same digest, which is what makes
 // the two repositories byte-identical rather than merely similar.
 const NATIVE_RUN_EVENTS_FIXTURE_SHA256 =
-  "a4e3e51168fd6d51d47b5baeb0579be892d4189c9f1231f34853b99744e41287";
+  "864384ebc620f2f0894390b45bd31635f757a230992da92351986cb0d0e53f94";
 
 const INPUT_REQUEST = {
   id: "8f2f1f52-0f2a-4a3a-9b0f-0f2a4a3a9b0f",
@@ -96,6 +97,15 @@ function buildSamples(): NativeRunEventFrame[] {
       url: "https://cdn.example.com/report.pdf",
       mediaType: "application/pdf",
       filename: "report.pdf",
+    }),
+    buildRuntimeEventRecordedEvent({
+      runtime: "veryfront",
+      kind: "runtime_context",
+      value: {
+        currentTimeUtc: "2026-09-09T00:00:00.000Z",
+        currentDateUtc: "2026-09-09",
+        runStartedAtUtc: "2026-09-09T00:00:00.000Z",
+      },
     }),
   ];
 }


### PR DESCRIPTION
## Summary

Follow-up to #4467 (stacked on `worktree-native-run-events`). The runtime emitted `data-veryfront.runtime_context` on every streaming run as an AG-UI `Custom` event; staging holds 4,393 such rows, unregistered in the API. It now emits the native `RUNTIME_EVENT_RECORDED` event:

```json
{ "type": "RUNTIME_EVENT_RECORDED", "runtime": "veryfront", "kind": "runtime_context", "value": { "currentTimeUtc": "...", "currentDateUtc": "...", "runStartedAtUtc": "..." } }
```

- Eighth entry in `NATIVE_RUN_EVENTS` (`src/agent/ag-ui/native-run-events.ts`) with a `buildRuntimeEventRecordedEvent` builder; one payload feeds the live frame and the durable record.
- Readers: the SSE parser table, `legacy-run-read-adapter.ts` (reads the native record back as the legacy `veryfront.runtime_context` custom twin), the chat decoder (maps the native frame to the same `data-veryfront.runtime_context` chunk), and the internal-agents allow-list.
- Contract fixture regenerated with the eighth sample; SHA-256 `864384ebc620f2f0894390b45bd31635f757a230992da92351986cb0d0e53f94`. The veryfront-api side (registering the name, the projector twin for historical rows, and the fixture copy) is a separate API PR.

Design: decision P12 in `docs/superpowers/specs/2026-09-09-native-run-events-producer-design.md`. Deploy order unchanged: after veryfront-api #4739 in the same environment.

## Test plan

- [x] RED-then-GREEN on the builder, encoder, readers, decoder and fixture digest
- [x] `deno task fmt`, `lint`, `lint:style`, `lint:anti-slop`, `lint:test-typecheck`, `lint:test-semantic-dispositions`, `typecheck`
- [x] `deno task test:unit` — full suite green
- [x] Reviewed (approved, no important findings)
- [ ] Codex review on the PR (the local codex CLI is at its usage limit until 2026-09-15)
- [ ] CI

https://claude.ai/code/session_01NonPHDcbWsisd2GFB68ALo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recording and transmitting runtime context events, including runtime, event kind, and flexible context data.
  - Runtime context is now available through AG-UI events and server-sent event streams.
  - Runtime context data is preserved when converting between current and legacy event formats.

- **Bug Fixes**
  - Improved handling of runtime context payloads, including non-object values, while maintaining compatibility with existing event consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->