### PR TITLE
perf(runtime): reduce request instrumentation and path resolution overhead

### DIFF
--- a/src/observability/request-profiler.test.ts
+++ b/src/observability/request-profiler.test.ts
@@ -251,6 +251,72 @@ describe("request profiler", () => {
     assertEquals(isRequestProfilingEnabled("/_veryfront/page-data/blog.json"), true);
   });
 
+  it("keeps repeated phase names sanitized and request durations independent", async () => {
+    const capture = (duration: number) =>
+      runWithRequestProfiling(
+        { category: "html", method: "GET", pathname: "/bench/phases" },
+        () => {
+          markRequestProfilePhase("render.ssr", duration);
+          markRequestProfilePhase("phase?token=<TOKEN>", duration);
+          markRequestProfilePhase("x".repeat(MAX_OBSERVABILITY_NAME_LENGTH + 1), duration);
+          return Promise.resolve(finalizeRequestProfiling(200));
+        },
+      );
+    const first = await capture(1);
+    // Exercise more distinct names than the per-request phase budget across sessions.
+    for (let i = 0; i < MAX_REQUEST_PROFILE_PHASES + 1; i++) {
+      await runWithRequestProfiling(
+        { category: "html", method: "GET", pathname: "/bench/phases" },
+        () => {
+          markRequestProfilePhase(`other.${i}`, 1);
+          finalizeRequestProfiling(200);
+          return Promise.resolve();
+        },
+      );
+    }
+    const second = await capture(2);
+    assertExists(first);
+    assertExists(second);
+    assertEquals(first.phases["render.ssr"], 1);
+    assertEquals(second.phases["render.ssr"], 2);
+    assertEquals(first.phases["phase?token=[REDACTED]"], 1);
+    assertEquals(second.phases["phase?token=[REDACTED]"], 2);
+    assertEquals(
+      Object.keys(second.phases).every((name) => name.length <= MAX_OBSERVABILITY_NAME_LENGTH),
+      true,
+    );
+    assertEquals(JSON.stringify(second).includes("<TOKEN>"), false);
+  });
+
+  it("does not expose raw phase names to replaced Set methods", async () => {
+    const originalHas = Set.prototype.has;
+    const originalAdd = Set.prototype.add;
+    const observed: unknown[] = [];
+    const sensitiveName = "phase?token=<TOKEN>";
+    try {
+      Set.prototype.has = function (value) {
+        observed.push(value);
+        return originalHas.call(this, value);
+      };
+      Set.prototype.add = function (value) {
+        observed.push(value);
+        return originalAdd.call(this, value);
+      };
+      await runWithRequestProfiling(
+        { category: "html", method: "GET", pathname: "/bench/phases" },
+        () => {
+          markRequestProfilePhase(sensitiveName, 1);
+          finalizeRequestProfiling(200);
+          return Promise.resolve();
+        },
+      );
+    } finally {
+      Set.prototype.has = originalHas;
+      Set.prototype.add = originalAdd;
+    }
+    assertEquals(observed.includes(sensitiveName), false);
+  });
+
   it("formats a Server-Timing header from total and phase durations", () => {
     const header = buildServerTimingHeader({
       sequence: 1,

--- a/src/observability/request-profiler.ts
+++ b/src/observability/request-profiler.ts
@@ -46,6 +46,26 @@ const storage = new AsyncLocalStorage<RequestProfileSession>();
 const records: RequestProfileRecord[] = [];
 const MAX_RECORDS = 200;
 let sequence = 0;
+// Retain only bounded names that the sanitizer leaves unchanged. Credential-
+// bearing input always goes through redaction and is never stored as a cache key.
+const sanitizedPhaseNames = new Set<string>();
+const apply = Reflect.apply;
+const setHas = Set.prototype.has;
+const setAdd = Set.prototype.add;
+const setClear = Set.prototype.clear;
+const setSize = Object.getOwnPropertyDescriptor(Set.prototype, "size")!.get!;
+
+function sanitizePhaseName(name: string): string {
+  if (apply(setHas, sanitizedPhaseNames, [name])) return name;
+  const sanitized = sanitizeTelemetryText(name, MAX_OBSERVABILITY_NAME_LENGTH);
+  if (
+    sanitized === name &&
+    apply(setSize, sanitizedPhaseNames, []) < MAX_REQUEST_PROFILE_PHASES
+  ) {
+    apply(setAdd, sanitizedPhaseNames, [name]);
+  }
+  return sanitized;
+}
 
 /** Round to 2 decimal places (Server-Timing millisecond precision). */
 export function roundMs(value: number): number {
@@ -59,7 +79,7 @@ function normalizeDuration(value: number): number {
 
 function addPhaseDuration(session: RequestProfileSession, name: string, durationMs: number): void {
   if (session.finalized || typeof name !== "string") return;
-  const normalizedName = sanitizeTelemetryText(name, MAX_OBSERVABILITY_NAME_LENGTH);
+  const normalizedName = sanitizePhaseName(name);
   if (
     !session.phases.has(normalizedName) &&
     session.phases.size >= MAX_REQUEST_PROFILE_PHASES
@@ -332,4 +352,5 @@ export function snapshotRequestProfiles(): {
 export function resetRequestProfiles(): void {
   records.length = 0;
   sequence = 0;
+  apply(setClear, sanitizedPhaseNames, []);
 }

--- a/src/platform/compat/path/portable.test.ts
+++ b/src/platform/compat/path/portable.test.ts
@@ -32,6 +32,25 @@ describe("platform/compat/path/portable", () => {
     assertEquals(portableJoin([""], false), "/");
   });
 
+  it("preserves canonical POSIX paths while normalizing traversal and separators", () => {
+    for (
+      const [input, expected] of [
+        ["/workspace/.config/file.ts", "/workspace/.config/file.ts"],
+        ["/workspace/café/日本語.ts", "/workspace/café/日本語.ts"],
+        ["/workspace/.../file.ts", "/workspace/.../file.ts"],
+        ["/workspace/./src/../file.ts", "/workspace/file.ts"],
+        ["/workspace//file.ts", "/workspace/file.ts"],
+        ["/workspace/src/..", "/workspace"],
+        ["/workspace/../../file.ts", "/file.ts"],
+        ["/workspace\\src\\..\\file.ts", "/workspace/file.ts"],
+        ["/workspace/src/", "/workspace/src/"],
+        ["/", "/"],
+      ]
+    ) {
+      assertEquals(portableNormalize(input!, false), expected);
+    }
+  });
+
   it("preserves Windows drive and UNC roots", () => {
     assertEquals(
       portableNormalize("D:\\workspace\\src\\..\\test", true),
@@ -76,6 +95,49 @@ describe("platform/compat/path/portable", () => {
       portableRelative("/workspace/src", "/workspace/test", false),
       "../test",
     );
+  });
+
+  it("resolves fully qualified paths without consulting the working directory", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Deno, "cwd")!;
+    let calls = 0;
+    try {
+      Object.defineProperty(Deno, "cwd", {
+        ...descriptor,
+        value: () => {
+          calls++;
+          return "/unrelated";
+        },
+      });
+      assertEquals(portableResolve(["/workspace/src", "..", "test"], false), "/workspace/test");
+      assertEquals(
+        portableResolve(["ignored", "/workspace", "file.ts"], false),
+        "/workspace/file.ts",
+      );
+      assertEquals(portableRelative("/workspace/src", "/workspace/test", false), "../test");
+      assertEquals(portableResolve(["C:/workspace", "..", "test"], true), "C:/test");
+      assertEquals(portableResolve(["C:/workspace", "/test"], true), "C:/test");
+      assertEquals(portableResolve(["//server/share", "test"], true), "//server/share/test");
+      assertEquals(calls, 0);
+    } finally {
+      Object.defineProperty(Deno, "cwd", descriptor);
+    }
+  });
+
+  it("reads the current directory afresh when resolution depends on it", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Deno, "cwd")!;
+    let current = "/first";
+    try {
+      Object.defineProperty(Deno, "cwd", { ...descriptor, value: () => current });
+      assertEquals(portableResolve(["file.ts"], false), "/first/file.ts");
+      current = "/second";
+      assertEquals(portableResolve([], false), "/second");
+      assertEquals(portableResolve(["file.ts"], false), "/second/file.ts");
+      current = "C:/workspace";
+      assertEquals(portableResolve(["C:child"], true), "C:/workspace/child");
+      assertEquals(portableResolve(["/rooted"], true), "C:/rooted");
+    } finally {
+      Object.defineProperty(Deno, "cwd", descriptor);
+    }
   });
 
   it("keeps path operations stable after post-import prototype poisoning", () => {

--- a/src/platform/compat/path/portable.test.ts
+++ b/src/platform/compat/path/portable.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import process from "node:process";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
@@ -98,10 +99,11 @@ describe("platform/compat/path/portable", () => {
   });
 
   it("resolves fully qualified paths without consulting the working directory", () => {
-    const descriptor = Object.getOwnPropertyDescriptor(Deno, "cwd")!;
+    const runtime = typeof Deno === "undefined" ? process : Deno;
+    const descriptor = Object.getOwnPropertyDescriptor(runtime, "cwd")!;
     let calls = 0;
     try {
-      Object.defineProperty(Deno, "cwd", {
+      Object.defineProperty(runtime, "cwd", {
         ...descriptor,
         value: () => {
           calls++;
@@ -119,15 +121,16 @@ describe("platform/compat/path/portable", () => {
       assertEquals(portableResolve(["//server/share", "test"], true), "//server/share/test");
       assertEquals(calls, 0);
     } finally {
-      Object.defineProperty(Deno, "cwd", descriptor);
+      Object.defineProperty(runtime, "cwd", descriptor);
     }
   });
 
   it("reads the current directory afresh when resolution depends on it", () => {
-    const descriptor = Object.getOwnPropertyDescriptor(Deno, "cwd")!;
+    const runtime = typeof Deno === "undefined" ? process : Deno;
+    const descriptor = Object.getOwnPropertyDescriptor(runtime, "cwd")!;
     let current = "/first";
     try {
-      Object.defineProperty(Deno, "cwd", { ...descriptor, value: () => current });
+      Object.defineProperty(runtime, "cwd", { ...descriptor, value: () => current });
       assertEquals(portableResolve(["file.ts"], false), "/first/file.ts");
       current = "/second";
       assertEquals(portableResolve([], false), "/second");
@@ -136,7 +139,7 @@ describe("platform/compat/path/portable", () => {
       assertEquals(portableResolve(["C:child"], true), "C:/workspace/child");
       assertEquals(portableResolve(["/rooted"], true), "C:/rooted");
     } finally {
-      Object.defineProperty(Deno, "cwd", descriptor);
+      Object.defineProperty(runtime, "cwd", descriptor);
     }
   });
 

--- a/src/platform/compat/path/portable.ts
+++ b/src/platform/compat/path/portable.ts
@@ -203,6 +203,13 @@ function runtimeCwd(): string {
 
 export function portableNormalize(path: string, windows: boolean): string {
   if (path === "") return ".";
+  // Most host filesystem paths are already canonical POSIX paths. Avoid
+  // splitting and rebuilding them; traversal, duplicate separators, backslashes,
+  // trailing separators, and Windows roots keep the full normalization path.
+  if (
+    !windows && path[0] === "/" && path[path.length - 1] !== "/" &&
+    matches(/[\\]|\/\/|\/\.{1,2}(?:\/|$)/, path) === null
+  ) return path;
 
   const root = analyzeRoot(path, windows);
   const tail = arrayJoin(normalizeTail(root.rest, root.absolute), "/");
@@ -310,9 +317,26 @@ export function portableResolve(
   paths: readonly string[],
   windows: boolean,
 ): string {
-  let resolved = runtimeCwd();
+  // A fully qualified segment discards everything to its left, including cwd.
+  // Windows root-relative and drive-relative segments still need the preceding
+  // drive, so only a root with a device can start resolution on Windows.
+  let resolved: string | undefined;
+  let start = 0;
+  for (let index = paths.length - 1; index >= 0; index--) {
+    const path = paths[index]!;
+    const root = windows ? analyzeRoot(path, true) : undefined;
+    const qualified = windows
+      ? root!.absolute && root!.device !== ""
+      : path[0] === "/" || path[0] === "\\";
+    if (qualified) {
+      resolved = toPortableSeparators(path);
+      start = index + 1;
+      break;
+    }
+  }
+  resolved ??= runtimeCwd();
 
-  for (let index = 0; index < paths.length; index++) {
+  for (let index = start; index < paths.length; index++) {
     const rawPath = paths[index]!;
     if (rawPath.length === 0) continue;
 


### PR DESCRIPTION
## Description

Warm requests repeatedly sanitize the same phase labels and resolve absolute filesystem paths through the working directory. Cache up to 128 phase names that sanitization leaves unchanged, and avoid working-directory reads and rebuilding already canonical absolute paths.

Relative paths still follow the current directory. Windows roots, traversal normalization, phase cardinality, redaction, and protection against replaced built-in methods retain regression coverage. No public API changes.

Earlier seven-trial measurements on Deno 2.7.7 / Apple M5 showed full synthetic HTTP latency reductions of 29% for API routes, 24% for cached pages, 15% for uncached production SSR, and 9% for development SSR. Those captures predate the current base; they are supporting evidence, not a claim about deployed traffic. Profiles and experiment notes remain untracked.

## Type of Change

- [x] Performance improvement
- [x] Test update

## Validation

- `deno task test:file src/observability/request-profiler.test.ts src/observability/telemetry-error.test.ts src/utils/logger/redact.test.ts src/platform/compat/path/`: 10 tests, 249 steps pass.
- `deno task test:file src/security/path-validation/ src/security/path-validation.test.ts src/security/secure-fs.test.ts src/platform/adapters/runtime/shared/node-filesystem-adapter.test.ts src/utils/path-utils.test.ts tests/integration/server/production/api.test.ts tests/integration/server/production/ssr.test.ts`: 22 tests, 404 steps pass.
- Focused Deno formatting and lint checks, plus `git diff --check`, pass.

## Checklist

- [x] Public behavior and API signatures remain compatible; no reference regeneration is needed.
- [x] Added focused regression tests and ran the surrounding security and HTTP integration suites.

The focused portable path suite also passes under Node 24 and CI-pinned Bun 1.3.6. The new working-directory mocks select the active runtime, fixing the Node and Bun CI failures observed on the previous head. Deno path tests, formatting, and lint pass after this test-only correction.
