### PR TITLE
fix(agent): authenticate platform MCP tools with the run invocation credential

### DIFF
--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -956,7 +956,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
           platformMcpFetchCalls += 1;
           assertEquals(
             new Headers(observeFetchRequestInit(init).headers).get("authorization"),
-            "Bearer run-scoped-token",
+            "Bearer request-scoped-user-token",
           );
           return Promise.resolve(
             new Response(
@@ -2768,7 +2768,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
         assertEquals(String(url), `${TEST_PUBLIC_API_ORIGIN}/mcp`);
         assertEquals(
           new Headers(observeFetchRequestInit(init).headers).get("authorization"),
-          "Bearer run-scoped-token",
+          "Bearer request-scoped-user-token",
         );
         const request = JSON.parse(String(observeFetchRequestInit(init).body)) as {
           id: string;
@@ -3063,7 +3063,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
         }
 
         if (String(url) === `${TEST_PUBLIC_API_ORIGIN}/mcp`) {
-          assertEquals(authorization, "Bearer run-scoped-token");
+          assertEquals(authorization, "Bearer request-scoped-user-token");
           capturedMcpRequest = {
             url: String(url),
             authorization,
@@ -3131,9 +3131,12 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertStringIncludes(capturedSystem ?? "", "project_reference=support-agent-fork");
     assertStringIncludes(capturedSystem ?? "", '<project_context>\nproject_reference: "proj-1"');
     assertEquals(capturedProjectContextToken, "run-scoped-token");
+    // The platform MCP source is framework-owned and authenticates with the
+    // verified run invocation credential; only project-code-visible surfaces
+    // (the agent environment above) keep the runtime's project credential.
     assertEquals(capturedMcpRequest, {
       url: `${TEST_PUBLIC_API_ORIGIN}/mcp`,
-      authorization: "Bearer run-scoped-token",
+      authorization: "Bearer request-scoped-user-token",
     });
     assertEquals(capturedAllowedRemoteTools, ["list_projects", "search_knowledge"]);
     assertEquals(capturedRemoteToolNames, ["search_knowledge", "list_projects"]);

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -1030,7 +1030,11 @@ export class AgentStreamHandler extends BaseHandler {
       // Project code and sandbox-backed tools may only receive the runtime's
       // existing project credential, never the credential supplied by the user.
       // The process host token is never combined with request-selected tenant
-      // identity, so it is not a fallback here either.
+      // identity, so it is not a fallback here either. The platform MCP tool
+      // source is framework-owned: it authenticates with the verified run
+      // invocation credential, whose scope profile authorizes the platform
+      // tool callbacks (files:write among them) that the stream credential
+      // deliberately lacks.
       const projectRuntimeToken = ctx.proxyToken || "";
       const requestScopedContext: HandlerContext = {
         ...ctx,
@@ -1192,7 +1196,7 @@ export class AgentStreamHandler extends BaseHandler {
                         const localTools = this.deps.getLocalTools?.(runtimeBaseAgent.id);
                         const platformRuntimeAgent = await withVeryfrontPlatformRemoteTools({
                           agent: runtimeBaseAgent as Agent,
-                          token: projectRuntimeToken || null,
+                          token: apiAuthToken || null,
                           projectId: projectScopedContext.projectId ?? null,
                           availableToolNames: runtimeInput.tools.map((tool) => tool.name),
                         });


### PR DESCRIPTION
## Problem

Hosted agent runs can read project files but cannot write them: every `create_file`/`update_file`/`delete_file` from a schedule-fired or control-plane-verified run fails with `[authorization-denied] Access denied`, while `get_file`/`list_files` succeed. This silently breaks every template that persists records from agents (verified live on `agentic-inbox-processing-outlook`; `agentic-job-submission-processing` last wrote successfully on 2026-09-02, before the current runtime rollout).

Full analysis: veryfront/veryfront-issue-inbox#1327

## Root cause

Since #4214 the hosted agent-stream path hands `withVeryfrontPlatformRemoteTools` the `projectRuntimeToken` (`ctx.proxyToken`) — the stream credential signed with `RUNTIME_SCOPES.runsStream`, which carries `files:read` but no `files:write`. The run invocation credential minted expressly for platform tool callbacks (`mintRuntimeInvocationAuthToken` → `runsExecute`, which does carry `files:write`) arrives as `payload.credentials.authToken` but only reached framework API calls, never the MCP tool source. veryfront-api's scope ladder then correctly denies the write.

## Fix

Pass the verified request credential (`apiAuthToken`) to the framework-owned platform MCP tool source. Project-code-visible surfaces are unchanged and keep the runtime's project credential: the agent environment (`VERYFRONT_API_TOKEN` env var), the sandbox (`projectAgentSandbox.authToken`), and Studio remote tools. This preserves #4214's isolation intent — project code and sandbox never see the run credential — while restoring the authority the invocation credential exists to provide ("The runtime calls integration tools back through the platform with this token").

`apiAuthToken` already falls back to `ctx.proxyToken` when the payload carries no credential, so behavior for token-less requests is unchanged.

## Red/green

The existing tests pinned the regressed routing. Red: flipping the platform-MCP authorization assertions to expect the request credential fails on main (3 tests: control-plane stream config, legacy stream policy identities, credential isolation). Green: the one-line token routing change. The isolation test's environment assertion (`VERYFRONT_API_TOKEN: "run-scoped-token"`) still passes untouched, demonstrating the env boundary holds.

`deno task test:file src/server/handlers/request/agent-stream.handler.test.ts` — 3 passed (67 steps), 0 failed. `deno check` + `deno lint` + `deno fmt --check` clean on touched files.

https://claude.ai/code/session_019B9SYdGjpN6sQ4424NLv91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Platform MCP requests now authenticate with the verified run invocation credential, improving authorization for platform tool callbacks.
  - Project-code-visible surfaces continue using the runtime’s project credential.
  - Updated request-handling tests to reflect the corrected authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->